### PR TITLE
Add support for third octave and custom frequency bands selection

### DIFF
--- a/noisemodelling-emission/src/main/java/org/noise_planet/noisemodelling/emission/jdbc/LDENComputeRaysOut.java
+++ b/noisemodelling-emission/src/main/java/org/noise_planet/noisemodelling/emission/jdbc/LDENComputeRaysOut.java
@@ -32,7 +32,7 @@ public class LDENComputeRaysOut extends ComputeRaysOut {
         }
 
         void processAndPushResult(long receiverPK, List<double[]> wjSources, ConcurrentLinkedDeque<VerticeSL> result) {
-            double[] levels = new double[PropagationProcessPathData.freq_lvl.size()];
+            double[] levels = new double[ldenComputeRaysOut.genericMeteoData.freq_lvl.size()];
             for (VerticeSL lvl : receiverAttenuationLevels) {
                 levels = ComputeRays.sumArray(levels,
                         ComputeRays.dbaToW(ComputeRays.sumArray(ComputeRays.wToDba(wjSources.get((int) lvl.sourceId)), lvl.value)));

--- a/noisemodelling-emission/src/main/java/org/noise_planet/noisemodelling/emission/jdbc/LDENConfig.java
+++ b/noisemodelling-emission/src/main/java/org/noise_planet/noisemodelling/emission/jdbc/LDENConfig.java
@@ -32,6 +32,7 @@ public class LDENConfig {
     public enum INPUT_MODE { INPUT_MODE_TRAFFIC_FLOW, INPUT_MODE_LW_DEN, INPUT_MODE_PROBA}
     final INPUT_MODE input_mode;
 
+    // This field is initialised when {@link PointNoiseMap#initialize} is called
     PropagationProcessPathData propagationProcessPathData = null;
 
     // Cnossos revisions have multiple coefficients for road emission formulae

--- a/noisemodelling-emission/src/main/java/org/noise_planet/noisemodelling/emission/jdbc/LDENConfig.java
+++ b/noisemodelling-emission/src/main/java/org/noise_planet/noisemodelling/emission/jdbc/LDENConfig.java
@@ -21,6 +21,8 @@
  */
 package org.noise_planet.noisemodelling.emission.jdbc;
 
+import org.noise_planet.noisemodelling.propagation.PropagationProcessPathData;
+
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -30,9 +32,7 @@ public class LDENConfig {
     public enum INPUT_MODE { INPUT_MODE_TRAFFIC_FLOW, INPUT_MODE_LW_DEN, INPUT_MODE_PROBA}
     final INPUT_MODE input_mode;
 
-    public LDENConfig(INPUT_MODE input_mode) {
-        this.input_mode = input_mode;
-    }
+    PropagationProcessPathData propagationProcessPathData = null;
 
     // Cnossos revisions have multiple coefficients for road emission formulae
     // this parameter will be removed when the final version of Cnossos will be published
@@ -59,6 +59,28 @@ public class LDENConfig {
     String lNightTable = "LNIGHT_RESULT";
     String lDenTable = "LDEN_RESULT";
     String raysTable = "RAYS";
+
+    String lwFrequencyPrepend = "LW";
+
+    public LDENConfig(INPUT_MODE input_mode) {
+        this.input_mode = input_mode;
+    }
+
+    public PropagationProcessPathData getPropagationProcessPathData() {
+        return propagationProcessPathData;
+    }
+
+    public String getLwFrequencyPrepend() {
+        return lwFrequencyPrepend;
+    }
+
+    public void setLwFrequencyPrepend(String lwFrequencyPrepend) {
+        this.lwFrequencyPrepend = lwFrequencyPrepend;
+    }
+
+    public void setPropagationProcessPathData(PropagationProcessPathData propagationProcessPathData) {
+        this.propagationProcessPathData = propagationProcessPathData;
+    }
 
     public void setComputeLDay(boolean computeLDay) {
         this.computeLDay = computeLDay;

--- a/noisemodelling-emission/src/main/java/org/noise_planet/noisemodelling/emission/jdbc/LDENPointNoiseMapFactory.java
+++ b/noisemodelling-emission/src/main/java/org/noise_planet/noisemodelling/emission/jdbc/LDENPointNoiseMapFactory.java
@@ -23,8 +23,10 @@
 package org.noise_planet.noisemodelling.emission.jdbc;
 
 import org.h2.jdbc.JdbcBatchUpdateException;
+import org.h2gis.utilities.JDBCUtilities;
 import org.h2gis.utilities.TableLocation;
 import org.noise_planet.noisemodelling.propagation.*;
+import org.noise_planet.noisemodelling.propagation.jdbc.JdbcNoiseMap;
 import org.noise_planet.noisemodelling.propagation.jdbc.PointNoiseMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,6 +35,10 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
 /**
@@ -49,6 +55,46 @@ public class LDENPointNoiseMapFactory implements PointNoiseMap.PropagationProces
     public LDENPointNoiseMapFactory(Connection connection, LDENConfig ldenConfig) {
         tableWriter = new TableWriter(connection, ldenConfig, ldenData);
         this.ldenConfig = ldenConfig;
+    }
+
+    @Override
+    public void initialize(Connection connection, PointNoiseMap pointNoiseMap) throws SQLException {
+        // Fetch source fields
+        List<String> sourceField = JDBCUtilities.getFieldNames(connection.getMetaData(), pointNoiseMap.getSourcesTableName());
+        List<Integer> frequencyValues = new ArrayList<>();
+        List<Integer> allFrequencyValues = Arrays.asList(PropagationProcessPathData.DEFAULT_FREQUENCIES_THIRD_OCTAVE);
+        String period = "";
+        if(ldenConfig.computeLDay) {
+            period = "D";
+        } else if(ldenConfig.computeLEvening) {
+            period = "E";
+        } else if(ldenConfig.computeLNight) {
+            period = "N";
+        }
+        String freqField = ldenConfig.lwFrequencyPrepend+period;
+        if(!period.isEmpty()) {
+            for (String fieldName : sourceField) {
+                if (fieldName.startsWith(freqField)) {
+                    int freq = Integer.parseInt(fieldName.substring(freqField.length()));
+                    int index = allFrequencyValues.indexOf(freq);
+                    if (index >= 0) {
+                        frequencyValues.add(freq);
+                    }
+                }
+            }
+        }
+        // Sort frequencies values
+        Collections.sort(frequencyValues);
+
+        List<Double> exactFrequencies = new ArrayList<>();
+        List<Double> aWeighting = new ArrayList<>();
+        for(int freq : frequencyValues) {
+            int index = allFrequencyValues.indexOf(freq);
+            exactFrequencies.add(PropagationProcessPathData.DEFAULT_FREQUENCIES_EXACT_THIRD_OCTAVE[index]);
+            aWeighting.add(PropagationProcessPathData.DEFAULT_FREQUENCIES_A_WEIGHTING_THIRD_OCTAVE[index]);
+        }
+        ldenConfig.propagationProcessPathData = new PropagationProcessPathData(frequencyValues, exactFrequencies,
+                aWeighting);
     }
 
     /**
@@ -125,9 +171,9 @@ public class LDENPointNoiseMapFactory implements PointNoiseMap.PropagationProces
             this.connection = connection;
             this.ldenConfig = ldenConfig;
             this.ldenData = ldenData;
-            a_weighting = new double[PropagationProcessPathData.freq_lvl_a_weighting.size()];
+            a_weighting = new double[ldenConfig.propagationProcessPathData.freq_lvl_a_weighting.size()];
             for(int idfreq = 0; idfreq < a_weighting.length; idfreq++) {
-                a_weighting[idfreq] = PropagationProcessPathData.freq_lvl_a_weighting.get(idfreq);
+                a_weighting[idfreq] = ldenConfig.propagationProcessPathData.freq_lvl_a_weighting.get(idfreq);
             }
         }
 
@@ -170,7 +216,7 @@ public class LDENPointNoiseMapFactory implements PointNoiseMap.PropagationProces
             if(!ldenConfig.mergeSources) {
                 query.append(", ?"); // ID_SOURCE
             }
-            for(int idfreq=0; idfreq < PropagationProcessPathData.freq_lvl.size(); idfreq++) {
+            for(int idfreq=0; idfreq < ldenConfig.propagationProcessPathData.freq_lvl.size(); idfreq++) {
                 query.append(", ?"); // freq value
             }
             query.append(", ?, ?);"); // laeq, leq
@@ -184,7 +230,7 @@ public class LDENPointNoiseMapFactory implements PointNoiseMap.PropagationProces
                 if(!ldenConfig.mergeSources) {
                     ps.setLong(parameterIndex++, row.sourceId);
                 }
-                for(int idfreq=0;idfreq < PropagationProcessPathData.freq_lvl.size(); idfreq++) {
+                for(int idfreq=0;idfreq < ldenConfig.propagationProcessPathData.freq_lvl.size(); idfreq++) {
                     Double value = row.value[idfreq];
                     if(!Double.isFinite(value)) {
                         value = -99.0;
@@ -220,9 +266,9 @@ public class LDENPointNoiseMapFactory implements PointNoiseMap.PropagationProces
             } else {
                 sb.append(" (IDRECEIVER SERIAL PRIMARY KEY");
             }
-            for (int idfreq = 0; idfreq < PropagationProcessPathData.freq_lvl.size(); idfreq++) {
+            for (int idfreq = 0; idfreq < ldenConfig.propagationProcessPathData.freq_lvl.size(); idfreq++) {
                 sb.append(", HZ");
-                sb.append(PropagationProcessPathData.freq_lvl.get(idfreq));
+                sb.append(ldenConfig.propagationProcessPathData.freq_lvl.get(idfreq));
                 sb.append(" numeric(5, 2)");
             }
             sb.append(", LAEQ numeric(5, 2), LEQ numeric(5, 2)");

--- a/noisemodelling-emission/src/main/java/org/noise_planet/noisemodelling/emission/jdbc/LDENPointNoiseMapFactory.java
+++ b/noisemodelling-emission/src/main/java/org/noise_planet/noisemodelling/emission/jdbc/LDENPointNoiseMapFactory.java
@@ -113,6 +113,8 @@ public class LDENPointNoiseMapFactory implements PointNoiseMap.PropagationProces
                 // Traffic flow cnossos frequencies are octave bands from 63 to 8000 Hz
                 ldenConfig.setPropagationProcessPathData(new PropagationProcessPathData(false));
                 pointNoiseMap.setPropagationProcessPathData(ldenConfig.propagationProcessPathData);
+            } else {
+                ldenConfig.setPropagationProcessPathData(pointNoiseMap.getPropagationProcessPathData());
             }
         }
     }

--- a/noisemodelling-emission/src/main/java/org/noise_planet/noisemodelling/emission/jdbc/LDENPointNoiseMapFactory.java
+++ b/noisemodelling-emission/src/main/java/org/noise_planet/noisemodelling/emission/jdbc/LDENPointNoiseMapFactory.java
@@ -66,7 +66,7 @@ public class LDENPointNoiseMapFactory implements PointNoiseMap.PropagationProces
             List<Integer> frequencyValues = new ArrayList<>();
             List<Integer> allFrequencyValues = Arrays.asList(PropagationProcessPathData.DEFAULT_FREQUENCIES_THIRD_OCTAVE);
             String period = "";
-            if (ldenConfig.computeLDay) {
+            if (ldenConfig.computeLDay || ldenConfig.computeLDEN) {
                 period = "D";
             } else if (ldenConfig.computeLEvening) {
                 period = "E";
@@ -94,6 +94,9 @@ public class LDENPointNoiseMapFactory implements PointNoiseMap.PropagationProces
                 int index = allFrequencyValues.indexOf(freq);
                 exactFrequencies.add(PropagationProcessPathData.DEFAULT_FREQUENCIES_EXACT_THIRD_OCTAVE[index]);
                 aWeighting.add(PropagationProcessPathData.DEFAULT_FREQUENCIES_A_WEIGHTING_THIRD_OCTAVE[index]);
+            }
+            if(frequencyValues.isEmpty()) {
+                throw new SQLException("Source table "+pointNoiseMap.getSourcesTableName()+" does not contains any frequency bands");
             }
             ldenConfig.setPropagationProcessPathData(new PropagationProcessPathData(frequencyValues, exactFrequencies, aWeighting));
         } else {

--- a/noisemodelling-emission/src/main/java/org/noise_planet/noisemodelling/emission/jdbc/LDENPointNoiseMapFactory.java
+++ b/noisemodelling-emission/src/main/java/org/noise_planet/noisemodelling/emission/jdbc/LDENPointNoiseMapFactory.java
@@ -98,10 +98,22 @@ public class LDENPointNoiseMapFactory implements PointNoiseMap.PropagationProces
             if(frequencyValues.isEmpty()) {
                 throw new SQLException("Source table "+pointNoiseMap.getSourcesTableName()+" does not contains any frequency bands");
             }
-            ldenConfig.setPropagationProcessPathData(new PropagationProcessPathData(frequencyValues, exactFrequencies, aWeighting));
+            // Instance of PropagationProcessPathData maybe already set
+            if(pointNoiseMap.getPropagationProcessPathData() == null) {
+                ldenConfig.setPropagationProcessPathData(new PropagationProcessPathData(frequencyValues, exactFrequencies, aWeighting));
+                pointNoiseMap.setPropagationProcessPathData(ldenConfig.propagationProcessPathData);
+            } else {
+                pointNoiseMap.getPropagationProcessPathData().setFrequencies(frequencyValues);
+                pointNoiseMap.getPropagationProcessPathData().setFrequenciesExact(exactFrequencies);
+                pointNoiseMap.getPropagationProcessPathData().setFrequenciesAWeighting(aWeighting);
+                ldenConfig.setPropagationProcessPathData(pointNoiseMap.getPropagationProcessPathData());
+            }
         } else {
-            // Traffic flow cnossos frequencies are octave bands from 63 to 8000 Hz
-            ldenConfig.setPropagationProcessPathData(new PropagationProcessPathData(false));
+            if(pointNoiseMap.getPropagationProcessPathData() == null) {
+                // Traffic flow cnossos frequencies are octave bands from 63 to 8000 Hz
+                ldenConfig.setPropagationProcessPathData(new PropagationProcessPathData(false));
+                pointNoiseMap.setPropagationProcessPathData(ldenConfig.propagationProcessPathData);
+            }
         }
     }
 

--- a/noisemodelling-emission/src/main/java/org/noise_planet/noisemodelling/emission/jdbc/LDENPointNoiseMapFactory.java
+++ b/noisemodelling-emission/src/main/java/org/noise_planet/noisemodelling/emission/jdbc/LDENPointNoiseMapFactory.java
@@ -85,7 +85,7 @@ public class LDENPointNoiseMapFactory implements PointNoiseMap.PropagationProces
         }
         // Sort frequencies values
         Collections.sort(frequencyValues);
-
+        // Get associated values for each frequency
         List<Double> exactFrequencies = new ArrayList<>();
         List<Double> aWeighting = new ArrayList<>();
         for(int freq : frequencyValues) {
@@ -93,8 +93,8 @@ public class LDENPointNoiseMapFactory implements PointNoiseMap.PropagationProces
             exactFrequencies.add(PropagationProcessPathData.DEFAULT_FREQUENCIES_EXACT_THIRD_OCTAVE[index]);
             aWeighting.add(PropagationProcessPathData.DEFAULT_FREQUENCIES_A_WEIGHTING_THIRD_OCTAVE[index]);
         }
-        ldenConfig.propagationProcessPathData = new PropagationProcessPathData(frequencyValues, exactFrequencies,
-                aWeighting);
+        ldenConfig.setPropagationProcessPathData(new PropagationProcessPathData(frequencyValues, exactFrequencies,
+                aWeighting));
     }
 
     /**

--- a/noisemodelling-emission/src/main/java/org/noise_planet/noisemodelling/emission/jdbc/LDENPropagationProcessData.java
+++ b/noisemodelling-emission/src/main/java/org/noise_planet/noisemodelling/emission/jdbc/LDENPropagationProcessData.java
@@ -42,7 +42,6 @@ import java.util.*;
  * Read source database and compute the sound emission spectrum of roads sources
  */
 public class LDENPropagationProcessData extends PropagationProcessData {
-    String lwFrequencyPrepend = "LW";
     public Map<String, Integer> sourceFields = null;
 
     // Source value in energetic  e = pow(10, dbVal / 10.0)
@@ -95,7 +94,7 @@ public class LDENPropagationProcessData extends PropagationProcessData {
                 sourceFields.put(fieldName.toUpperCase(), fieldId++);
             }
         }
-        double[] lvl = new double[PropagationProcessPathData.freq_lvl.size()];
+        double[] lvl = new double[ldenConfig.propagationProcessPathData.freq_lvl.size()];
         // Set default values
         double tv = 0; // old format "total vehicles"
         double hv = 0; // old format "heavy vehicles"
@@ -185,7 +184,7 @@ public class LDENPropagationProcessData extends PropagationProcessData {
         }
         // Compute emission
         int idFreq = 0;
-        for (int freq : PropagationProcessPathData.freq_lvl) {
+        for (int freq : ldenConfig.propagationProcessPathData.freq_lvl) {
             RSParametersCnossos rsParametersCnossos = new RSParametersCnossos(lv_speed, mv_speed, hgv_speed, wav_speed,
                     wbv_speed,lvPerHour, mvPerHour, hgvPerHour, wavPerHour, wbvPerHour, freq, temperature,
                     roadSurface, tsStud, pmStud, junctionDistance, junctionType);
@@ -199,31 +198,31 @@ public class LDENPropagationProcessData extends PropagationProcessData {
     public double[][] computeLw(SpatialResultSet rs) throws SQLException {
 
         // Compute day average level
-        double[] ld = new double[PropagationProcessPathData.freq_lvl.size()];
-        double[] le = new double[PropagationProcessPathData.freq_lvl.size()];
-        double[] ln = new double[PropagationProcessPathData.freq_lvl.size()];
-        double[] lden = new double[PropagationProcessPathData.freq_lvl.size()];
+        double[] ld = new double[ldenConfig.propagationProcessPathData.freq_lvl.size()];
+        double[] le = new double[ldenConfig.propagationProcessPathData.freq_lvl.size()];
+        double[] ln = new double[ldenConfig.propagationProcessPathData.freq_lvl.size()];
+        double[] lden = new double[ldenConfig.propagationProcessPathData.freq_lvl.size()];
 
         if (ldenConfig.input_mode == LDENConfig.INPUT_MODE.INPUT_MODE_PROBA) {
             double val = ComputeRays.dbaToW(90.0);
-            for(int idfreq = 0; idfreq < PropagationProcessPathData.freq_lvl.size(); idfreq++) {
+            for(int idfreq = 0; idfreq < ldenConfig.propagationProcessPathData.freq_lvl.size(); idfreq++) {
                 ld[idfreq] = ComputeRays.dbaToW(val);
                 le[idfreq] = ComputeRays.dbaToW(val);
                 ln[idfreq] = ComputeRays.dbaToW(val);
             }
         } else if (ldenConfig.input_mode == LDENConfig.INPUT_MODE.INPUT_MODE_LW_DEN) {
             // Read average 24h traffic
-            for (int idfreq = 0; idfreq < PropagationProcessPathData.freq_lvl.size(); idfreq++) {
-                ld[idfreq] = ComputeRays.dbaToW(rs.getDouble(lwFrequencyPrepend + "D" +
-                        PropagationProcessPathData.freq_lvl.get(idfreq)));
+            for (int idfreq = 0; idfreq < ldenConfig.propagationProcessPathData.freq_lvl.size(); idfreq++) {
+                ld[idfreq] = ComputeRays.dbaToW(rs.getDouble(ldenConfig.lwFrequencyPrepend + "D" +
+                        ldenConfig.propagationProcessPathData.freq_lvl.get(idfreq)));
             }
-            for (int idfreq = 0; idfreq < PropagationProcessPathData.freq_lvl.size(); idfreq++) {
-                le[idfreq] = ComputeRays.dbaToW(rs.getDouble(lwFrequencyPrepend + "E" +
-                        PropagationProcessPathData.freq_lvl.get(idfreq)));
+            for (int idfreq = 0; idfreq < ldenConfig.propagationProcessPathData.freq_lvl.size(); idfreq++) {
+                le[idfreq] = ComputeRays.dbaToW(rs.getDouble(ldenConfig.lwFrequencyPrepend + "E" +
+                        ldenConfig.propagationProcessPathData.freq_lvl.get(idfreq)));
             }
-            for (int idfreq = 0; idfreq < PropagationProcessPathData.freq_lvl.size(); idfreq++) {
-                ln[idfreq] = ComputeRays.dbaToW(rs.getDouble(lwFrequencyPrepend + "N" +
-                        PropagationProcessPathData.freq_lvl.get(idfreq)));
+            for (int idfreq = 0; idfreq < ldenConfig.propagationProcessPathData.freq_lvl.size(); idfreq++) {
+                ln[idfreq] = ComputeRays.dbaToW(rs.getDouble(ldenConfig.lwFrequencyPrepend + "N" +
+                        ldenConfig.propagationProcessPathData.freq_lvl.get(idfreq)));
             }
         } else if(ldenConfig.input_mode == LDENConfig.INPUT_MODE.INPUT_MODE_TRAFFIC_FLOW) {
             // Extract road slope
@@ -255,7 +254,7 @@ public class LDENPropagationProcessData extends PropagationProcessData {
         }
 
         // Combine day evening night sound levels
-        for (int idfreq = 0; idfreq < PropagationProcessPathData.freq_lvl.size(); idfreq++) {
+        for (int idfreq = 0; idfreq < ldenConfig.propagationProcessPathData.freq_lvl.size(); idfreq++) {
             lden[idfreq] = (12 * ld[idfreq] + 4 * ComputeRays.dbaToW(ComputeRays.wToDba(le[idfreq]) + 5) + 8 * ComputeRays.dbaToW(ComputeRays.wToDba(ln[idfreq]) + 10)) / 24.0;
         }
 

--- a/noisemodelling-emission/src/main/java/org/noise_planet/noisemodelling/emission/jdbc/LDENPropagationProcessData.java
+++ b/noisemodelling-emission/src/main/java/org/noise_planet/noisemodelling/emission/jdbc/LDENPropagationProcessData.java
@@ -212,17 +212,20 @@ public class LDENPropagationProcessData extends PropagationProcessData {
             }
         } else if (ldenConfig.input_mode == LDENConfig.INPUT_MODE.INPUT_MODE_LW_DEN) {
             // Read average 24h traffic
-            for (int idfreq = 0; idfreq < ldenConfig.propagationProcessPathData.freq_lvl.size(); idfreq++) {
-                ld[idfreq] = ComputeRays.dbaToW(rs.getDouble(ldenConfig.lwFrequencyPrepend + "D" +
-                        ldenConfig.propagationProcessPathData.freq_lvl.get(idfreq)));
+            if(ldenConfig.computeLDay || ldenConfig.computeLDEN) {
+                for (int idfreq = 0; idfreq < ldenConfig.propagationProcessPathData.freq_lvl.size(); idfreq++) {
+                    ld[idfreq] = ComputeRays.dbaToW(rs.getDouble(ldenConfig.lwFrequencyPrepend + "D" + ldenConfig.propagationProcessPathData.freq_lvl.get(idfreq)));
+                }
             }
-            for (int idfreq = 0; idfreq < ldenConfig.propagationProcessPathData.freq_lvl.size(); idfreq++) {
-                le[idfreq] = ComputeRays.dbaToW(rs.getDouble(ldenConfig.lwFrequencyPrepend + "E" +
-                        ldenConfig.propagationProcessPathData.freq_lvl.get(idfreq)));
+            if(ldenConfig.computeLEvening || ldenConfig.computeLDEN) {
+                for (int idfreq = 0; idfreq < ldenConfig.propagationProcessPathData.freq_lvl.size(); idfreq++) {
+                    le[idfreq] = ComputeRays.dbaToW(rs.getDouble(ldenConfig.lwFrequencyPrepend + "E" + ldenConfig.propagationProcessPathData.freq_lvl.get(idfreq)));
+                }
             }
-            for (int idfreq = 0; idfreq < ldenConfig.propagationProcessPathData.freq_lvl.size(); idfreq++) {
-                ln[idfreq] = ComputeRays.dbaToW(rs.getDouble(ldenConfig.lwFrequencyPrepend + "N" +
-                        ldenConfig.propagationProcessPathData.freq_lvl.get(idfreq)));
+            if(ldenConfig.computeLNight || ldenConfig.computeLDEN) {
+                for (int idfreq = 0; idfreq < ldenConfig.propagationProcessPathData.freq_lvl.size(); idfreq++) {
+                    ln[idfreq] = ComputeRays.dbaToW(rs.getDouble(ldenConfig.lwFrequencyPrepend + "N" + ldenConfig.propagationProcessPathData.freq_lvl.get(idfreq)));
+                }
             }
         } else if(ldenConfig.input_mode == LDENConfig.INPUT_MODE.INPUT_MODE_TRAFFIC_FLOW) {
             // Extract road slope

--- a/noisemodelling-emission/src/test/java/org/noise_planet/noisemodelling/emission/jdbc/LDENPointNoiseMapFactoryTest.java
+++ b/noisemodelling-emission/src/test/java/org/noise_planet/noisemodelling/emission/jdbc/LDENPointNoiseMapFactoryTest.java
@@ -250,4 +250,60 @@ public class LDENPointNoiseMapFactoryTest {
             assertEquals(83,rs.getDouble(10), 2.0);
         }
     }
+
+    @Test
+    public void testReadFrequencies() throws SQLException, IOException {
+        SHPRead.readShape(connection, LDENPointNoiseMapFactoryTest.class.getResource("lw_roads.shp").getFile());
+        SHPRead.readShape(connection, LDENPointNoiseMapFactoryTest.class.getResource("buildings.shp").getFile());
+        SHPRead.readShape(connection, LDENPointNoiseMapFactoryTest.class.getResource("receivers.shp").getFile());
+
+        LDENConfig ldenConfig = new LDENConfig(LDENConfig.INPUT_MODE.INPUT_MODE_LW_DEN);
+
+        LDENPointNoiseMapFactory factory = new LDENPointNoiseMapFactory(connection, ldenConfig);
+
+        PointNoiseMap pointNoiseMap = new PointNoiseMap("BUILDINGS", "LW_ROADS",
+                "RECEIVERS");
+
+        pointNoiseMap.setComputeRaysOutFactory(factory);
+        pointNoiseMap.setPropagationProcessDataFactory(factory);
+
+        pointNoiseMap.initialize(connection, new EmptyProgressVisitor());
+
+        assertNotNull(ldenConfig.propagationProcessPathData);
+
+        assertEquals(8, ldenConfig.propagationProcessPathData.freq_lvl.size());
+
+        try(Statement st = connection.createStatement()) {
+            // drop all columns except 1000 Hz
+            st.execute("ALTER TABLE lw_roads drop column LWD63");
+            st.execute("ALTER TABLE lw_roads drop column LWD125");
+            st.execute("ALTER TABLE lw_roads drop column LWD250");
+            st.execute("ALTER TABLE lw_roads drop column LWD500");
+            st.execute("ALTER TABLE lw_roads drop column LWD2000");
+            st.execute("ALTER TABLE lw_roads drop column LWD4000");
+            st.execute("ALTER TABLE lw_roads drop column LWD8000");
+            st.execute("ALTER TABLE lw_roads drop column LWE63");
+            st.execute("ALTER TABLE lw_roads drop column LWE125");
+            st.execute("ALTER TABLE lw_roads drop column LWE250");
+            st.execute("ALTER TABLE lw_roads drop column LWE500");
+            st.execute("ALTER TABLE lw_roads drop column LWE1000");
+            st.execute("ALTER TABLE lw_roads drop column LWE2000");
+            st.execute("ALTER TABLE lw_roads drop column LWE4000");
+            st.execute("ALTER TABLE lw_roads drop column LWE8000");
+            st.execute("ALTER TABLE lw_roads drop column LWN63");
+            st.execute("ALTER TABLE lw_roads drop column LWN125");
+            st.execute("ALTER TABLE lw_roads drop column LWN250");
+            st.execute("ALTER TABLE lw_roads drop column LWN500");
+            st.execute("ALTER TABLE lw_roads drop column LWN1000");
+            st.execute("ALTER TABLE lw_roads drop column LWN2000");
+            st.execute("ALTER TABLE lw_roads drop column LWN4000");
+            st.execute("ALTER TABLE lw_roads drop column LWN8000");
+        }
+
+        pointNoiseMap.initialize(connection, new EmptyProgressVisitor());
+
+        assertEquals(1, ldenConfig.propagationProcessPathData.freq_lvl.size());
+
+        assertEquals(1000, (int)ldenConfig.propagationProcessPathData.freq_lvl.get(0));
+    }
 }

--- a/noisemodelling-emission/src/test/java/org/noise_planet/noisemodelling/emission/jdbc/LDENPointNoiseMapFactoryTest.java
+++ b/noisemodelling-emission/src/test/java/org/noise_planet/noisemodelling/emission/jdbc/LDENPointNoiseMapFactoryTest.java
@@ -45,6 +45,7 @@ public class LDENPointNoiseMapFactoryTest {
     public void testNoiseEmission() throws SQLException, IOException {
         SHPRead.readShape(connection, LDENPointNoiseMapFactoryTest.class.getResource("roads_traff.shp").getFile());
         LDENConfig ldenConfig = new LDENConfig(LDENConfig.INPUT_MODE.INPUT_MODE_TRAFFIC_FLOW);
+        ldenConfig.setPropagationProcessPathData(new PropagationProcessPathData());
         ldenConfig.setCoefficientVersion(1);
         LDENPropagationProcessData process = new LDENPropagationProcessData(null, ldenConfig);
         try(Statement st = connection.createStatement()) {
@@ -125,10 +126,11 @@ public class LDENPointNoiseMapFactoryTest {
         Set<Long> receivers = new HashSet<>();
 
         try {
-            factory.start();
             RootProgressVisitor progressLogger = new RootProgressVisitor(1, true, 1);
 
             pointNoiseMap.initialize(connection, new EmptyProgressVisitor());
+
+            factory.start();
 
             pointNoiseMap.setGridDim(4); // force grid size
 

--- a/noisemodelling-emission/src/test/java/org/noise_planet/noisemodelling/emission/jdbc/LDENPointNoiseMapFactoryTest.java
+++ b/noisemodelling-emission/src/test/java/org/noise_planet/noisemodelling/emission/jdbc/LDENPointNoiseMapFactoryTest.java
@@ -171,8 +171,8 @@ public class LDENPointNoiseMapFactoryTest {
         // Check dB ranges of result
         try(ResultSet rs = connection.createStatement().executeQuery("SELECT MAX(HZ63) , MAX(HZ125), MAX(HZ250), MAX(HZ500), MAX(HZ1000), MAX(HZ2000), MAX(HZ4000), MAX(HZ8000), MAX(LEQ), MAX(LAEQ) FROM "+ ldenConfig.lDayTable)) {
             assertTrue(rs.next());
-            double[] leqs = new double[PropagationProcessPathData.freq_lvl.size()];
-            for(int idfreq = 1; idfreq <= PropagationProcessPathData.freq_lvl.size(); idfreq++) {
+            double[] leqs = new double[ldenConfig.propagationProcessPathData.freq_lvl.size()];
+            for(int idfreq = 1; idfreq <= ldenConfig.propagationProcessPathData.freq_lvl.size(); idfreq++) {
                 leqs[idfreq - 1] = rs.getDouble(idfreq);
             }
             assertEquals(83, leqs[0], 2.0);
@@ -192,8 +192,8 @@ public class LDENPointNoiseMapFactoryTest {
 
         try(ResultSet rs = connection.createStatement().executeQuery("SELECT MAX(HZ63) , MAX(HZ125), MAX(HZ250), MAX(HZ500), MAX(HZ1000), MAX(HZ2000), MAX(HZ4000), MAX(HZ8000), MAX(LEQ), MAX(LAEQ) FROM "+ ldenConfig.lEveningTable)) {
             assertTrue(rs.next());
-            double[] leqs = new double[PropagationProcessPathData.freq_lvl.size()];
-            for (int idfreq = 1; idfreq <= PropagationProcessPathData.freq_lvl.size(); idfreq++) {
+            double[] leqs = new double[ldenConfig.propagationProcessPathData.freq_lvl.size()];
+            for (int idfreq = 1; idfreq <= ldenConfig.propagationProcessPathData.freq_lvl.size(); idfreq++) {
                 leqs[idfreq - 1] = rs.getDouble(idfreq);
             }
             assertEquals(76.0, leqs[0], 2.0);
@@ -212,8 +212,8 @@ public class LDENPointNoiseMapFactoryTest {
 
         try(ResultSet rs = connection.createStatement().executeQuery("SELECT MAX(HZ63) , MAX(HZ125), MAX(HZ250), MAX(HZ500), MAX(HZ1000), MAX(HZ2000), MAX(HZ4000), MAX(HZ8000), MAX(LEQ), MAX(LAEQ) FROM "+ ldenConfig.lNightTable)) {
             assertTrue(rs.next());
-            double[] leqs = new double[PropagationProcessPathData.freq_lvl.size()];
-            for (int idfreq = 1; idfreq <= PropagationProcessPathData.freq_lvl.size(); idfreq++) {
+            double[] leqs = new double[ldenConfig.propagationProcessPathData.freq_lvl.size()];
+            for (int idfreq = 1; idfreq <= ldenConfig.propagationProcessPathData.freq_lvl.size(); idfreq++) {
                 leqs[idfreq - 1] = rs.getDouble(idfreq);
             }
             assertEquals(83.0, leqs[0], 2.0);
@@ -231,8 +231,8 @@ public class LDENPointNoiseMapFactoryTest {
 
         try(ResultSet rs = connection.createStatement().executeQuery("SELECT MAX(HZ63) , MAX(HZ125), MAX(HZ250), MAX(HZ500), MAX(HZ1000), MAX(HZ2000), MAX(HZ4000), MAX(HZ8000), MAX(LEQ), MAX(LAEQ) FROM "+ ldenConfig.lDenTable)) {
             assertTrue(rs.next());
-            double[] leqs = new double[PropagationProcessPathData.freq_lvl.size()];
-            for (int idfreq = 1; idfreq <= PropagationProcessPathData.freq_lvl.size(); idfreq++) {
+            double[] leqs = new double[ldenConfig.propagationProcessPathData.freq_lvl.size()];
+            for (int idfreq = 1; idfreq <= ldenConfig.propagationProcessPathData.freq_lvl.size(); idfreq++) {
                 leqs[idfreq - 1] = rs.getDouble(idfreq);
             }
             assertEquals(82.0, leqs[0], 2.0);

--- a/noisemodelling-propagation/src/main/java/org/noise_planet/noisemodelling/propagation/ComputeRays.java
+++ b/noisemodelling-propagation/src/main/java/org/noise_planet/noisemodelling/propagation/ComputeRays.java
@@ -578,8 +578,8 @@ public class ComputeRays {
 
         segments.add(new SegmentPath(gPath, new Vector3D(projSource, projReceiver),pInit));
 
-        points.add(new PointPath(srcCoord, altS, data.gS, Double.NaN, -1, PointPath.POINT_TYPE.SRCE));
-        points.add(new PointPath(receiverCoord, altR, data.gS, Double.NaN, -1, PointPath.POINT_TYPE.RECV));
+        points.add(new PointPath(srcCoord, altS, data.gS, new ArrayList<>(), -1, PointPath.POINT_TYPE.SRCE));
+        points.add(new PointPath(receiverCoord, altR, data.gS, new ArrayList<>(), -1, PointPath.POINT_TYPE.RECV));
 
         return new PropagationPath(false, points, segments, segments);
 

--- a/noisemodelling-propagation/src/main/java/org/noise_planet/noisemodelling/propagation/EvaluateAttenuationCnossos.java
+++ b/noisemodelling-propagation/src/main/java/org/noise_planet/noisemodelling/propagation/EvaluateAttenuationCnossos.java
@@ -334,13 +334,13 @@ public class EvaluateAttenuationCnossos {
         aGlobal = new double[data.freq_lvl.size()];
         double[] aBoundary ;
         double[] aRef ;
-        nbfreq = PropagationProcessPathData.freq_lvl.size();
+        nbfreq = data.freq_lvl.size();
 
         // Init wave length for each frequency
         freq_lambda = new double[nbfreq];
         for (int idf = 0; idf < nbfreq; idf++) {
-            if (PropagationProcessPathData.freq_lvl.get(idf) > 0) {
-                freq_lambda[idf] = data.getCelerity() / PropagationProcessPathData.freq_lvl.get(idf);
+            if (data.freq_lvl.get(idf) > 0) {
+                freq_lambda[idf] = data.getCelerity() / data.freq_lvl.get(idf);
             } else {
                 freq_lambda[idf] = 1;
             }

--- a/noisemodelling-propagation/src/main/java/org/noise_planet/noisemodelling/propagation/MeshBuilder.java
+++ b/noisemodelling-propagation/src/main/java/org/noise_planet/noisemodelling/propagation/MeshBuilder.java
@@ -90,13 +90,6 @@ public class MeshBuilder {
             this.hasHeight = height < Double.MAX_VALUE;
         }
 
-        public PolygonWithHeight(Geometry geo, double height, double alphaUniqueValue) {
-            this.geo = geo;
-            this.height = height;
-            this.hasHeight = height < Double.MAX_VALUE;
-            setAlpha(alphaUniqueValue);
-        }
-
         public PolygonWithHeight copy() {
             PolygonWithHeight copy = new PolygonWithHeight(geo, height, alpha);
             copy.alphaUniqueValue = alphaUniqueValue;
@@ -142,17 +135,6 @@ public class MeshBuilder {
          */
         public void setAlpha(List<Double> alpha) {
             this.alpha = Collections.unmodifiableList(new ArrayList<>(alpha));
-        }
-
-        /**
-         * @param alphaUniqueValue Set absorption coefficient of walls
-         */
-        public void setAlpha(double alphaUniqueValue) {
-            List<Double> newAlpha = new ArrayList<>(PropagationProcessPathData.freq_lvl.size());
-            for(double freq : PropagationProcessPathData.freq_lvl_exact) {
-                newAlpha.add(getWallAlpha(alphaUniqueValue, freq));
-            }
-            this.alpha = newAlpha;
         }
 
         public double getHeight() {
@@ -288,13 +270,14 @@ public class MeshBuilder {
         return coordinates;
     }
 
-    public void addGeometry(Geometry obstructionPoly) {
-        addGeometry(new PolygonWithHeight(obstructionPoly));
+    public PolygonWithHeight addGeometry(Geometry obstructionPoly) {
+        return addGeometry(new PolygonWithHeight(obstructionPoly));
     }
 
-    private void addGeometry(PolygonWithHeight poly) {
+    private PolygonWithHeight addGeometry(PolygonWithHeight poly) {
         this.geometriesBoundingBox.expandToInclude(poly.getGeometry().getEnvelopeInternal());
         polygonWithHeight.add(poly);
+        return poly;
     }
 
 
@@ -305,20 +288,8 @@ public class MeshBuilder {
      * @param obstructionPoly  building's Geometry
      * @param heightofBuilding building's Height
      */
-    public void addGeometry(Geometry obstructionPoly, double heightofBuilding) {
-        addGeometry(new PolygonWithHeight(obstructionPoly, heightofBuilding));
-    }
-
-    /**
-     * Add a new building with height and merge this new building with existing buildings if they have intersections
-     * When we merge the buildings, we will use The shortest height to new building
-     *
-     * @param obstructionPoly  building's Geometry
-     * @param heightofBuilding building's Height
-     * @param alpha Wall absorption coefficient
-     */
-    public void addGeometry(Geometry obstructionPoly, double heightofBuilding, List<Double> alpha) {
-        addGeometry(new PolygonWithHeight(obstructionPoly, heightofBuilding, alpha));
+    public PolygonWithHeight addGeometry(Geometry obstructionPoly, double heightofBuilding) {
+        return addGeometry(new PolygonWithHeight(obstructionPoly, heightofBuilding));
     }
 
     /**
@@ -329,26 +300,24 @@ public class MeshBuilder {
      * @param heightofBuilding building's Height
      * @param alpha Wall absorption coefficient
      */
-    public void addGeometry(Geometry obstructionPoly, double heightofBuilding, double[] alpha) {
+    public PolygonWithHeight addGeometry(Geometry obstructionPoly, double heightofBuilding, List<Double> alpha) {
+        return addGeometry(new PolygonWithHeight(obstructionPoly, heightofBuilding, alpha));
+    }
+
+    /**
+     * Add a new building with height and merge this new building with existing buildings if they have intersections
+     * When we merge the buildings, we will use The shortest height to new building
+     *
+     * @param obstructionPoly  building's Geometry
+     * @param heightofBuilding building's Height
+     * @param alpha Wall absorption coefficient
+     */
+    public PolygonWithHeight addGeometry(Geometry obstructionPoly, double heightofBuilding, double[] alpha) {
         List<Double> alphaw = new ArrayList<>(alpha.length);
         for(double a : alpha) {
             alphaw.add(a);
         }
-        addGeometry(new PolygonWithHeight(obstructionPoly, heightofBuilding, alphaw));
-    }
-
-    /**
-     * Add a new building with height and merge this new building with existing buildings if they have intersections
-     * When we merge the buildings, we will use The shortest height to new building
-     *
-     * @param obstructionPoly  building's Geometry
-     * @param heightofBuilding building's Height
-     * @param alpha Wall absorption coefficient
-     */
-    public PolygonWithHeight addGeometry(Geometry obstructionPoly, double heightofBuilding, double alpha) {
-        PolygonWithHeight poly = new PolygonWithHeight(obstructionPoly, heightofBuilding, alpha);
-        addGeometry(poly);
-        return poly;
+        return addGeometry(new PolygonWithHeight(obstructionPoly, heightofBuilding, alphaw));
     }
 
     public void mergeBuildings(Geometry boundingBoxGeom) {

--- a/noisemodelling-propagation/src/main/java/org/noise_planet/noisemodelling/propagation/PointPath.java
+++ b/noisemodelling-propagation/src/main/java/org/noise_planet/noisemodelling/propagation/PointPath.java
@@ -66,24 +66,6 @@ public class PointPath {
         this.type = type;
     }
 
-    /**
-     * parameters given by user
-     * @param coordinate
-     * @param altitude
-     * @param gs
-     * @param alpha
-     * @param buildingId
-     * @param type
-     */
-    public PointPath(Coordinate coordinate, double altitude, double gs, double alpha, int buildingId, POINT_TYPE type) {
-        this.coordinate = coordinate;
-        this.altitude = altitude;
-        this.gs = gs;
-        this.alphaWall = Collections.nCopies(PropagationProcessPathData.freq_lvl.size(), alpha);
-        this.buildingId = buildingId;
-        this.type = type;
-    }
-
     public PointPath() {
 
     }
@@ -98,8 +80,9 @@ public class PointPath {
         PropagationPath.writeCoordinate(out, coordinate);
         out.writeDouble(altitude);
         out.writeDouble(gs);
-        for (int j = 0; j< PropagationProcessPathData.freq_lvl.size(); j++){
-            out.writeDouble(alphaWall.get(j));
+        out.writeShort(alphaWall.size());
+        for (Double bandAlpha : alphaWall) {
+            out.writeDouble(bandAlpha);
         }
         out.writeInt(buildingId);
         out.writeInt(type.ordinal());
@@ -116,8 +99,9 @@ public class PointPath {
         coordinate = PropagationPath.readCoordinate(in);
         altitude = in.readDouble();
         gs = in.readDouble();
-        ArrayList<Double> readAlpha = new ArrayList<>(PropagationProcessPathData.freq_lvl.size());
-        for (int j = 0; j< PropagationProcessPathData.freq_lvl.size(); j++){
+        int nbFreq = in.readShort();
+        ArrayList<Double> readAlpha = new ArrayList<>(nbFreq);
+        for (int j = 0; j< nbFreq; j++){
             readAlpha.add(in.readDouble());
         }
         this.alphaWall = readAlpha;

--- a/noisemodelling-propagation/src/main/java/org/noise_planet/noisemodelling/propagation/PropagationProcessData.java
+++ b/noisemodelling-propagation/src/main/java/org/noise_planet/noisemodelling/propagation/PropagationProcessData.java
@@ -39,7 +39,9 @@ import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.h2gis.api.ProgressVisitor;
 import org.locationtech.jts.geom.GeometryFactory;
+import org.noise_planet.noisemodelling.propagation.jdbc.JdbcNoiseMap;
 
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/noisemodelling-propagation/src/main/java/org/noise_planet/noisemodelling/propagation/PropagationProcessPathData.java
+++ b/noisemodelling-propagation/src/main/java/org/noise_planet/noisemodelling/propagation/PropagationProcessPathData.java
@@ -33,11 +33,6 @@
  */
 package org.noise_planet.noisemodelling.propagation;
 
-import org.h2gis.api.ProgressVisitor;
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.Geometry;
-
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;

--- a/noisemodelling-propagation/src/main/java/org/noise_planet/noisemodelling/propagation/PropagationProcessPathData.java
+++ b/noisemodelling-propagation/src/main/java/org/noise_planet/noisemodelling/propagation/PropagationProcessPathData.java
@@ -57,9 +57,9 @@ public class PropagationProcessPathData {
     static final  double KvibN = 3352.0;// Vibrational temperature of the nitrogen (K)
     static final  double K01 = 273.16;  // Isothermal temperature at the triple point (K)
     static final double a8 = (2 * Math.PI / 35.0) * 10 * Math.log10(Math.pow(Math.exp(1),2));
-    public static final Integer[] DEFAULT_FREQUENCIES_THIRD_OCTAVE = new Integer[] {25, 31, 40, 50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630, 800, 1000, 1250, 1600, 2000, 2500, 3150, 4000, 5000, 6300, 8000, 10000};
-    public static final Double[] DEFAULT_FREQUENCIES_EXACT_THIRD_OCTAVE = new Double[] {25.1188643, 31.6227766, 39.8107171, 50.1187234, 63.0957344, 79.4328235, 100.0, 125.892541, 158.489319, 199.526231, 251.188643, 316.227766, 398.107171, 501.187234, 630.957344, 794.328235, 1000.0, 11258.92541, 1584.89319, 1995.26231, 2511.88643, 3162.27766, 3981.07171, 5011.87234, 6309.57344, 7943.28235, 10000.0};
-    public static final Double[] DEFAULT_FREQUENCIES_A_WEIGHTING_THIRD_OCTAVE = new Double[] {-44.7, -39.4, -34.6, -30.2, -26.2, -22.5, -19.1, -16.1, -13.4, -10.9, -8.6, -6.6, -4.8, -3.2, -1.9, -0.8, 0.0, 0.6, 1.0, 1.2, 1.3, 1.2, 1.0, 0.5, -0.1, -1.1, -2.5};
+    public static final Integer[] DEFAULT_FREQUENCIES_THIRD_OCTAVE = new Integer[] {50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630, 800, 1000, 1250, 1600, 2000, 2500, 3150, 4000, 5000, 6300, 8000, 10000};
+    public static final Double[] DEFAULT_FREQUENCIES_EXACT_THIRD_OCTAVE = new Double[] {50.1187234, 63.0957344, 79.4328235, 100.0, 125.892541, 158.489319, 199.526231, 251.188643, 316.227766, 398.107171, 501.187234, 630.957344, 794.328235, 1000.0, 11258.92541, 1584.89319, 1995.26231, 2511.88643, 3162.27766, 3981.07171, 5011.87234, 6309.57344, 7943.28235, 10000.0};
+    public static final Double[] DEFAULT_FREQUENCIES_A_WEIGHTING_THIRD_OCTAVE = new Double[] {-30.2, -26.2, -22.5, -19.1, -16.1, -13.4, -10.9, -8.6, -6.6, -4.8, -3.2, -1.9, -0.8, 0.0, 0.6, 1.0, 1.2, 1.3, 1.2, 1.0, 0.5, -0.1, -1.1, -2.5};
     /** Frequency bands values, by third octave */
     public final List<Integer> freq_lvl;
     public final List<Double> freq_lvl_exact;
@@ -123,9 +123,9 @@ public class PropagationProcessPathData {
      * @return Octave bands array
      */
     public static Integer[] asOctaveBands(Integer[] thirdOctaveBands) {
-        Integer[] octaveBands = new Integer[(thirdOctaveBands.length - 3) / 3];
+        Integer[] octaveBands = new Integer[thirdOctaveBands.length / 3];
         int j = 0;
-        for (int i = 4; i < thirdOctaveBands.length - 1; i += 3) {
+        for (int i = 1; i < thirdOctaveBands.length - 1; i += 3) {
             octaveBands[j++] = thirdOctaveBands[i];
         }
         return octaveBands;
@@ -138,9 +138,9 @@ public class PropagationProcessPathData {
      * @return Octave bands array
      */
     public static Double[] asOctaveBands(Double[] thirdOctaveBands) {
-        Double[] octaveBands = new Double[(thirdOctaveBands.length - 3) / 3];
+        Double[] octaveBands = new Double[thirdOctaveBands.length / 3];
         int j = 0;
-        for (int i = 4; i < thirdOctaveBands.length - 1; i += 3) {
+        for (int i = 1; i < thirdOctaveBands.length - 1; i += 3) {
             octaveBands[j++] = thirdOctaveBands[i];
         }
         return octaveBands;

--- a/noisemodelling-propagation/src/main/java/org/noise_planet/noisemodelling/propagation/PropagationProcessPathData.java
+++ b/noisemodelling-propagation/src/main/java/org/noise_planet/noisemodelling/propagation/PropagationProcessPathData.java
@@ -56,9 +56,9 @@ public class PropagationProcessPathData {
     public static final Double[] DEFAULT_FREQUENCIES_EXACT_THIRD_OCTAVE = new Double[] {50.1187234, 63.0957344, 79.4328235, 100.0, 125.892541, 158.489319, 199.526231, 251.188643, 316.227766, 398.107171, 501.187234, 630.957344, 794.328235, 1000.0, 11258.92541, 1584.89319, 1995.26231, 2511.88643, 3162.27766, 3981.07171, 5011.87234, 6309.57344, 7943.28235, 10000.0};
     public static final Double[] DEFAULT_FREQUENCIES_A_WEIGHTING_THIRD_OCTAVE = new Double[] {-30.2, -26.2, -22.5, -19.1, -16.1, -13.4, -10.9, -8.6, -6.6, -4.8, -3.2, -1.9, -0.8, 0.0, 0.6, 1.0, 1.2, 1.3, 1.2, 1.0, 0.5, -0.1, -1.1, -2.5};
     /** Frequency bands values, by third octave */
-    public final List<Integer> freq_lvl;
-    public final List<Double> freq_lvl_exact;
-    public final List<Double> freq_lvl_a_weighting;
+    public List<Integer> freq_lvl;
+    public List<Double> freq_lvl_exact;
+    public List<Double> freq_lvl_a_weighting;
     // Wind rose for each directions
     public static final double[] DEFAULT_WIND_ROSE = new double[]{0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5};
     /** Temperature in celsius */
@@ -109,6 +109,30 @@ public class PropagationProcessPathData {
 
     void init() {
         this.alpha_atmo = getAtmoCoeffArray(freq_lvl_exact,  temperature,  pressure,  humidity);
+    }
+
+    public List<Integer> getFrequencies() {
+        return freq_lvl;
+    }
+
+    public void setFrequencies(List<Integer> freq_lvl) {
+        this.freq_lvl = freq_lvl;
+    }
+
+    public List<Double> getFrequenciesExact() {
+        return freq_lvl_exact;
+    }
+
+    public void setFrequenciesExact(List<Double> freq_lvl_exact) {
+        this.freq_lvl_exact = freq_lvl_exact;
+    }
+
+    public List<Double> getFrequenciesAWeighting() {
+        return freq_lvl_a_weighting;
+    }
+
+    public void setFrequenciesAWeighting(List<Double> freq_lvl_a_weighting) {
+        this.freq_lvl_a_weighting = freq_lvl_a_weighting;
     }
 
     /**

--- a/noisemodelling-propagation/src/main/java/org/noise_planet/noisemodelling/propagation/PropagationProcessPathData.java
+++ b/noisemodelling-propagation/src/main/java/org/noise_planet/noisemodelling/propagation/PropagationProcessPathData.java
@@ -57,17 +57,21 @@ public class PropagationProcessPathData {
     static final  double KvibN = 3352.0;// Vibrational temperature of the nitrogen (K)
     static final  double K01 = 273.16;  // Isothermal temperature at the triple point (K)
     static final double a8 = (2 * Math.PI / 35.0) * 10 * Math.log10(Math.pow(Math.exp(1),2));
+    public static final Integer[] DEFAULT_FREQUENCIES_THIRD_OCTAVE = new Integer[] {25, 31, 40, 50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630, 800, 1000, 1250, 1600, 2000, 2500, 3150, 4000, 5000, 6300, 8000, 10000};
+    public static final Double[] DEFAULT_FREQUENCIES_EXACT_THIRD_OCTAVE = new Double[] {25.1188643, 31.6227766, 39.8107171, 50.1187234, 63.0957344, 79.4328235, 100.0, 125.892541, 158.489319, 199.526231, 251.188643, 316.227766, 398.107171, 501.187234, 630.957344, 794.328235, 1000.0, 11258.92541, 1584.89319, 1995.26231, 2511.88643, 3162.27766, 3981.07171, 5011.87234, 6309.57344, 7943.28235, 10000.0};
+    public static final Double[] DEFAULT_FREQUENCIES_A_WEIGHTING_THIRD_OCTAVE = new Double[] {-44.7, -39.4, -34.6, -30.2, -26.2, -22.5, -19.1, -16.1, -13.4, -10.9, -8.6, -6.6, -4.8, -3.2, -1.9, -0.8, 0.0, 0.6, 1.0, 1.2, 1.3, 1.2, 1.0, 0.5, -0.1, -1.1, -2.5};
     /** Frequency bands values, by third octave */
-    public static final List<Integer> freq_lvl = Arrays.asList(63, 125, 250, 500, 1000, 2000, 4000, 8000);
-    public static final List<Double> freq_lvl_exact = Arrays.asList(63.0957, 125.8925, 251.1888, 501.1872, 1000.0, 1995.26231, 3981.07171, 7943.28235);
-    public static final List<Double> freq_lvl_a_weighting = Arrays.asList(-26.2, -16.1, -8.6, -3.2, 0.0, 1.2, 1.0, -1.1);
+    public final List<Integer> freq_lvl;
+    public final List<Double> freq_lvl_exact;
+    public final List<Double> freq_lvl_a_weighting;
+    // Wind rose for each directions
     public static final double[] DEFAULT_WIND_ROSE = new double[]{0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5};
     /** Temperature in celsius */
     private double temperature = 15;
     private double celerity = 340;
     private double humidity = 70;
     private double pressure = Pref;
-    private double[] alpha_atmo = getAtmoCoeffArray(freq_lvl_exact,  temperature,  pressure,  humidity);
+    private double[] alpha_atmo;
     private double defaultOccurance = 0.5;
 
     private boolean gDisc = true;     // choose between accept G discontinuity or not
@@ -75,6 +79,72 @@ public class PropagationProcessPathData {
     /** probability occurrence favourable condition */
     private double[] windRose  = DEFAULT_WIND_ROSE;
 
+    public PropagationProcessPathData() {
+        this(false);
+    }
+
+
+    public PropagationProcessPathData(boolean thirdOctave) {
+        if(!thirdOctave) {
+            // Default frequencies are in octave bands
+            freq_lvl = Arrays.asList(asOctaveBands(DEFAULT_FREQUENCIES_THIRD_OCTAVE));
+            freq_lvl_exact = Arrays.asList(asOctaveBands(DEFAULT_FREQUENCIES_EXACT_THIRD_OCTAVE));
+            freq_lvl_a_weighting = Arrays.asList(asOctaveBands(DEFAULT_FREQUENCIES_A_WEIGHTING_THIRD_OCTAVE));
+        } else {
+            // third octave bands
+            freq_lvl = Arrays.asList(DEFAULT_FREQUENCIES_THIRD_OCTAVE);
+            freq_lvl_exact = Arrays.asList(DEFAULT_FREQUENCIES_EXACT_THIRD_OCTAVE);
+            freq_lvl_a_weighting = Arrays.asList(DEFAULT_FREQUENCIES_A_WEIGHTING_THIRD_OCTAVE);
+        }
+        init();
+    }
+
+    /**
+     * @param freq_lvl Frequency values for column names
+     * @param freq_lvl_exact Exact frequency values for computations
+     * @param freq_lvl_a_weighting A weighting values
+     */
+    public PropagationProcessPathData(List<Integer> freq_lvl, List<Double> freq_lvl_exact,
+                                      List<Double> freq_lvl_a_weighting) {
+        this.freq_lvl = Collections.unmodifiableList(freq_lvl);
+        this.freq_lvl_exact = Collections.unmodifiableList(freq_lvl_exact);
+        this.freq_lvl_a_weighting = Collections.unmodifiableList(freq_lvl_a_weighting);
+        init();
+    }
+
+    void init() {
+        this.alpha_atmo = getAtmoCoeffArray(freq_lvl_exact,  temperature,  pressure,  humidity);
+    }
+
+    /**
+     * Create new array by taking middle third octave bands
+     *
+     * @param thirdOctaveBands Third octave bands array
+     * @return Octave bands array
+     */
+    public static Integer[] asOctaveBands(Integer[] thirdOctaveBands) {
+        Integer[] octaveBands = new Integer[(thirdOctaveBands.length - 3) / 3];
+        int j = 0;
+        for (int i = 4; i < thirdOctaveBands.length - 1; i += 3) {
+            octaveBands[j++] = thirdOctaveBands[i];
+        }
+        return octaveBands;
+    }
+
+    /**
+     * Create new array by taking middle third octave bands
+     *
+     * @param thirdOctaveBands Third octave bands array
+     * @return Octave bands array
+     */
+    public static Double[] asOctaveBands(Double[] thirdOctaveBands) {
+        Double[] octaveBands = new Double[(thirdOctaveBands.length - 3) / 3];
+        int j = 0;
+        for (int i = 4; i < thirdOctaveBands.length - 1; i += 3) {
+            octaveBands[j++] = thirdOctaveBands[i];
+        }
+        return octaveBands;
+    }
     /**
      * Set relative humidity in percentage.
      * @param humidity relative humidity in percentage. 0-100

--- a/noisemodelling-propagation/src/main/java/org/noise_planet/noisemodelling/propagation/jdbc/PointNoiseMap.java
+++ b/noisemodelling-propagation/src/main/java/org/noise_planet/noisemodelling/propagation/jdbc/PointNoiseMap.java
@@ -33,16 +33,11 @@ public class PointNoiseMap extends JdbcNoiseMap {
     private PropagationProcessDataFactory propagationProcessDataFactory;
     private IComputeRaysOutFactory computeRaysOutFactory;
     private Logger logger = LoggerFactory.getLogger(PointNoiseMap.class);
-    private PropagationProcessPathData propagationProcessPathData = new PropagationProcessPathData();
     private int threadCount = 0;
 
     public PointNoiseMap(String buildingsTableName, String sourcesTableName, String receiverTableName) {
         super(buildingsTableName, sourcesTableName);
         this.receiverTableName = receiverTableName;
-    }
-
-    public void setPropagationProcessPathData(PropagationProcessPathData propagationProcessPathData) {
-        this.propagationProcessPathData = propagationProcessPathData;
     }
 
     public void setComputeRaysOutFactory(IComputeRaysOutFactory computeRaysOutFactory) {
@@ -248,8 +243,18 @@ public class PointNoiseMap extends JdbcNoiseMap {
         return computeRaysOut;
     }
 
+    @Override
+    public void initialize(Connection connection, ProgressVisitor progression) throws SQLException {
+        super.initialize(connection, progression);
+        if(propagationProcessDataFactory != null) {
+            propagationProcessDataFactory.initialize(connection, this);
+        }
+    }
+
     public interface PropagationProcessDataFactory {
         PropagationProcessData create(FastObstructionTest freeFieldFinder);
+
+        void initialize(Connection connection, PointNoiseMap pointNoiseMap) throws SQLException;
     }
 
     public interface IComputeRaysOutFactory {

--- a/noisemodelling-propagation/src/test/java/org/noise_planet/noisemodelling/propagation/AtmosphericAttenuationTest.java
+++ b/noisemodelling-propagation/src/test/java/org/noise_planet/noisemodelling/propagation/AtmosphericAttenuationTest.java
@@ -35,6 +35,9 @@ package org.noise_planet.noisemodelling.propagation;
 
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.List;
+
 import static junit.framework.Assert.assertEquals;
 
 /**
@@ -42,6 +45,7 @@ import static junit.framework.Assert.assertEquals;
  */
 public class AtmosphericAttenuationTest {
     private static final double EPSILON = 0.1;
+    private static final List<Double> freq_lvl_exact = Arrays.asList(PropagationProcessPathData.asOctaveBands(PropagationProcessPathData.DEFAULT_FREQUENCIES_EXACT_THIRD_OCTAVE));
 
     @Test
     public void atmoTestMinus20degree() {
@@ -50,7 +54,7 @@ public class AtmosphericAttenuationTest {
         double pressure = 101325;
         final double[] expected = new double[] {0.173,0.514,1.73,5.29,11.5,16.6,20.2,27.8};
         for(int idfreq=0;idfreq< expected.length;idfreq++) {
-            double freq = PropagationProcessPathData.freq_lvl_exact.get(idfreq);
+            double freq = freq_lvl_exact.get(idfreq);
             double coefAttAtmos = PropagationProcessPathData.getCoefAttAtmos(freq, humidity,pressure,temperature+PropagationProcessPathData.K_0);
             assertEquals(expected[idfreq], coefAttAtmos, EPSILON);
         }
@@ -63,7 +67,7 @@ public class AtmosphericAttenuationTest {
         double pressure = 101325;
         final double[] expected = new double[] {0.188,0.532,1.76,5.61,13.2,20.5,25.2,33.2};
         for(int idfreq=0;idfreq< expected.length;idfreq++) {
-            double freq = PropagationProcessPathData.freq_lvl_exact.get(idfreq);
+            double freq = freq_lvl_exact.get(idfreq);
             double coefAttAtmos = PropagationProcessPathData.getCoefAttAtmos(freq, humidity,pressure,temperature+PropagationProcessPathData.K_0);
             assertEquals(expected[idfreq], coefAttAtmos, EPSILON);
         }
@@ -76,7 +80,7 @@ public class AtmosphericAttenuationTest {
         double pressure = 101325;
         final double[] expected = new double[] {0.165,0.401,0.779,1.78,5.5,19.3,63.3,154.4};
         for(int idfreq=0;idfreq< expected.length;idfreq++) {
-            double freq = PropagationProcessPathData.freq_lvl_exact.get(idfreq);
+            double freq = freq_lvl_exact.get(idfreq);
             double coefAttAtmos = PropagationProcessPathData.getCoefAttAtmos(freq, humidity,pressure,temperature+PropagationProcessPathData.K_0);
             assertEquals(expected[idfreq], coefAttAtmos, EPSILON);
         }
@@ -89,7 +93,7 @@ public class AtmosphericAttenuationTest {
         double pressure = 101325;
         final double[] expected = new double[] {0.079,0.302,1.04,2.77,5.15,8.98,21.3,68.6};
         for(int idfreq=0;idfreq< expected.length;idfreq++) {
-            double freq = PropagationProcessPathData.freq_lvl_exact.get(idfreq);
+            double freq = freq_lvl_exact.get(idfreq);
             double coefAttAtmos = PropagationProcessPathData.getCoefAttAtmos(freq, humidity,pressure,temperature+PropagationProcessPathData.K_0);
             assertEquals(expected[idfreq], coefAttAtmos, EPSILON);
         }
@@ -103,7 +107,7 @@ public class AtmosphericAttenuationTest {
         double pressure = 101325;
         final double[] expected = new double[] {0.12, 0.41, 1.04, 1.93, 3.66, 9.66, 32.77, 116.88};
         for(int idfreq=0;idfreq< expected.length;idfreq++) {
-            double freq = PropagationProcessPathData.freq_lvl_exact.get(idfreq);
+            double freq = freq_lvl_exact.get(idfreq);
             double coefAttAtmos = PropagationProcessPathData.getCoefAttAtmos(freq, humidity,pressure,temperature+PropagationProcessPathData.K_0);
             assertEquals(expected[idfreq], coefAttAtmos, EPSILON);
         }

--- a/noisemodelling-propagation/src/test/java/org/noise_planet/noisemodelling/propagation/EvaluateAttenuationCnossosTest.java
+++ b/noisemodelling-propagation/src/test/java/org/noise_planet/noisemodelling/propagation/EvaluateAttenuationCnossosTest.java
@@ -958,8 +958,9 @@ public class EvaluateAttenuationCnossosTest {
         DirectPropagationProcessData rayData = new DirectPropagationProcessData(manager);
         rayData.addReceiver(new Coordinate(200, 50, 11.5));
 
+        PropagationProcessPathData attData = new PropagationProcessPathData();
         // Push source with sound level
-        rayData.addSource(factory.createPoint(new Coordinate(10, 10, 1)), ComputeRays.dbaToW(aWeighting(Collections.nCopies(PropagationProcessPathData.freq_lvl.size(), 93d))));
+        rayData.addSource(factory.createPoint(new Coordinate(10, 10, 1)), ComputeRays.dbaToW(aWeighting(Collections.nCopies(attData.freq_lvl.size(), 93d))));
 
         rayData.setComputeHorizontalDiffraction(true);
         rayData.addSoilType(new GeoWithSoilType(factory.toGeometry(new Envelope(0, 50, -100, 100)), 0.9));
@@ -969,7 +970,6 @@ public class EvaluateAttenuationCnossosTest {
         rayData.setComputeVerticalDiffraction(true);
         rayData.setGs(0.9);
 
-        PropagationProcessPathData attData = new PropagationProcessPathData();
         attData.setHumidity(70);
         attData.setTemperature(10);
         attData.setPrime2520(false);
@@ -1859,7 +1859,7 @@ public class EvaluateAttenuationCnossosTest {
         evaluateAttenuationCnossos.evaluate(propPath, pathData);
         double[] aGlobalMeteoHom = evaluateAttenuationCnossos.getaGlobal();
         for(int i = 0; i < aGlobalMeteoHom.length; i++) {
-            assertFalse(String.format("freq %d Hz with nan value",PropagationProcessPathData.freq_lvl.get(i)), Double.isNaN(aGlobalMeteoHom[i]));
+            assertFalse(String.format("freq %d Hz with nan value",pathData.freq_lvl.get(i)), Double.isNaN(aGlobalMeteoHom[i]));
         }
 
     }

--- a/noisemodelling-propagation/src/test/java/org/noise_planet/noisemodelling/propagation/EvaluateAttenuationCnossosTest.java
+++ b/noisemodelling-propagation/src/test/java/org/noise_planet/noisemodelling/propagation/EvaluateAttenuationCnossosTest.java
@@ -11,9 +11,7 @@ import org.locationtech.jts.io.WKTReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayInputStream;
-import java.io.DataInputStream;
-import java.io.IOException;
+import java.io.*;
 import java.util.*;
 
 import static org.junit.Assert.*;
@@ -1834,32 +1832,41 @@ public class EvaluateAttenuationCnossosTest {
      */
     @Test
     public void TestRegressionNaN() throws LayerDelaunayError, IOException {
-        String path = "AAAAAAAAAAAAAAAABkELTp9wo7AcQVnI2rXCgfo/qZmZmZmZmgAAAAAAAAAAAAAAAAAAAAB/+AAAAAAAAH/4AAAAAAAAf" +
-                "/gAAAAAAAB/+AAAAAAAAH/4AAAAAAAAf/gAAAAAAAB/+AAAAAAAAH/4AAAAAAAA" +
-                "/////wAAAABBC1AyUqFAN0FZyLag3BoSQCXYkAb18EtAFU46DH/X4gAAAAAAAAAAf/gAAAAAAAB/+AAAAAAAAH/4AAAAAAAAf" +
-                "/gAAAAAAAB/+AAAAAAAAH/4AAAAAAAAf/gAAAAAAAB/+AAAAAAAAP////8AAAADQQtSgYVM4atBWciBrnR" +
-                "/N0A2aoP8x7ilQBy3Mx4IxFoAAAAAAAAAAH/4AAAAAAAAf/gAAAAAAAB/+AAAAAAAAH/4AAAAAAAAf/gAAAAAAAB/+AAAAAAAAH" +
-                "/4AAAAAAAAf/gAAAAAAAD/////AAAAA0ELUo/NRf1KQVnIgGcH8SZANmqD/Me4pUAe4TEhnNY1AAAAAAAAAAB/+AAAAAAAAH" +
-                "/4AAAAAAAAf/gAAAAAAAB/+AAAAAAAAH/4AAAAAAAAf/gAAAAAAAB/+AAAAAAAAH/4AAAAAAAA" +
-                "/////wAAAANBC1NUa4Kow0FZyG7LKg/OQDDZILDUkCJAJUagr26FpAAAAAAAAAAAf/gAAAAAAAB/+AAAAAAAAH/4AAAAAAAAf" +
-                "/gAAAAAAAB/+AAAAAAAAH/4AAAAAAAAf/gAAAAAAAB/+AAAAAAAAP" +
-                "////8AAAADQQtTd2Mz1AZBWchrqXZ4aEAt2dfMwxGBQCXZ18zDEYEAAAAAAAAAAH/4AAAAAAAAf/gAAAAAAAB/+AAAAAAAAH" +
+        String path = "AAAAAAAAAAAAAAAABkELTp9wo7AcQVnI2rXCgfo/qZmZmZmZmgAAAAAAAAAAAAAAAAAAAAAACH/4AAAAAAAAf" +
+                "/gAAAAAAAB/+AAAAAAAAH/4AAAAAAAAf/gAAAAAAAB/+AAAAAAAAH/4AAAAAAAAf/gAAAAAAAD" +
+                "/////AAAAAEELUDJSoUA3QVnItqDcGhJAJdiQBvXwS0AVTjoMf9fiAAAAAAAAAAAACH/4AAAAAAAAf/gAAAAAAAB/+AAAAAAAAH" +
+                "/4AAAAAAAAf/gAAAAAAAB/+AAAAAAAAH/4AAAAAAAAf/gAAAAAAAD/////AAAAA0ELUoGFTOGrQVnIga50fzdANmqD" +
+                "/Me4pUActzMeCMRaAAAAAAAAAAAACH/4AAAAAAAAf/gAAAAAAAB/+AAAAAAAAH/4AAAAAAAAf/gAAAAAAAB/+AAAAAAAAH" +
+                "/4AAAAAAAAf/gAAAAAAAD/////AAAAA0ELUo/NRf1KQVnIgGcH8SZANmqD/Me4pUAe4TEhnNY1AAAAAAAAAAAACH/4AAAAAAAAf" +
+                "/gAAAAAAAB/+AAAAAAAAH/4AAAAAAAAf/gAAAAAAAB/+AAAAAAAAH/4AAAAAAAAf/gAAAAAAAD" +
+                "/////AAAAA0ELU1RrgqjDQVnIbssqD85AMNkgsNSQIkAlRqCvboWkAAAAAAAAAAAACH/4AAAAAAAAf/gAAAAAAAB/+AAAAAAAAH" +
+                "/4AAAAAAAAf/gAAAAAAAB/+AAAAAAAAH/4AAAAAAAAf/gAAAAAAAD" +
+                "/////AAAAA0ELU3djM9QGQVnIa6l2eGhALdnXzMMRgUAl2dfMwxGBAAAAAAAAAAAACH/4AAAAAAAAf/gAAAAAAAB/+AAAAAAAAH" +
                 "/4AAAAAAAAf/gAAAAAAAB/+AAAAAAAAH/4AAAAAAAAf/gAAAAAAAD/////AAAABAAAAAU/wBvxnrf6hkBJLxOOJzAAwGILIc" +
                 "/cAABAJRdmLHGkLkELTp9xTapHQVnI2rWzSOi/jTelQ3f5WD/hNUTOrUdwQFJ6WqIZaADAanpOelWAAD/odGaWtL" +
                 "+wQQtQMkhBG1pBWci2ocn7h0ASDrQig+tyAAAAAAAAAAA/+uzqKo4AAMATSo/AwAAAP/Qml6qEHQRBC1J9yb" +
                 "/w6kFZyIIECGuLQBb5xfFciCQAAAAAAAAAAEA4e506acAAwFGKjYvwAABABNd1zN" +
                 "/3IEELUo8N2d3pQVnIgHgsr3lAIC98kZ14SQAAAAAAAAAAQBFrZiGsAADAKPYLaTAAAD" +
-                "/SoWVrORNgQQtTU81vkgNBWchu2VI9a0AlRuFfAqJXAAAAAT" +
-                "/TBsY8SUi2QGNg7UkPZADAe8S0CsKAAEAVMZUczyA2QQtOn1fPWpRBWcjat/vFwUAKJWO95msG";
+                "/SoWVrORNgQQtTU81vkgNBWchu2VI9a0AlRuFfAqJXAAAAAz" +
+                "/TBsY8SUi2QGNg7UkPZADAe8S0CsKAAEAVMZUczyA2QQtOn1fPWpRBWcjat" +
+                "/vFwUAKJWO95msGP9MGxjxJSLZAY2CN2WJwAMB7xCtJq4AAQCDgvd4PLeBBC06fP717akFZyNq6I58WQBnyM91nx0E" +
+                "/0wbGPElItkBjYUy4vFgAwHvFPMvZgABAAUNc+v/JNkELTp9Xz1qUQVnI2rf7xcFACiVjveZrBg==";
         PropagationPath propPath = new PropagationPath();
         propPath.readStream(new DataInputStream(new ByteArrayInputStream(Base64.getDecoder().decode(path))));
         propPath.initPropagationPath();
+
+        //        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        //        propPath.writeStream(new DataOutputStream(bos));
+        //        String newVersion  = new String(Base64.getEncoder().encode(bos.toByteArray()));
+        //        System.out.println(newVersion);
+
         EvaluateAttenuationCnossos evaluateAttenuationCnossos = new EvaluateAttenuationCnossos();
         PropagationProcessPathData pathData = new PropagationProcessPathData();
         evaluateAttenuationCnossos.evaluate(propPath, pathData);
         double[] aGlobalMeteoHom = evaluateAttenuationCnossos.getaGlobal();
-        for(int i = 0; i < aGlobalMeteoHom.length; i++) {
-            assertFalse(String.format("freq %d Hz with nan value",pathData.freq_lvl.get(i)), Double.isNaN(aGlobalMeteoHom[i]));
+        for (int i = 0; i < aGlobalMeteoHom.length; i++) {
+            assertFalse(String.format("freq %d Hz with nan value", pathData.freq_lvl.get(i)),
+                    Double.isNaN(aGlobalMeteoHom[i]));
         }
 
     }

--- a/noisemodelling-propagation/src/test/java/org/noise_planet/noisemodelling/propagation/PropagationPath_Cnossos.java
+++ b/noisemodelling-propagation/src/test/java/org/noise_planet/noisemodelling/propagation/PropagationPath_Cnossos.java
@@ -51,8 +51,8 @@ public class PropagationPath_Cnossos {
         Vector3D flatTopography = new Vector3D(new Coordinate(0,0,0),new Coordinate(0,0,0));
 
         points.add(new PointPath(new Coordinate(0,0,0),1,0,new double[0], -1, PointPath.POINT_TYPE.SRCE));
-        points.add(new PointPath(new Coordinate(10,0,0),1,Double.NaN,0.5, -1, PointPath.POINT_TYPE.DIFH));
-        points.add(new PointPath(new Coordinate(20,0,0),1,Double.NaN,0.5, -1, PointPath.POINT_TYPE.DIFH));
+        points.add(new PointPath(new Coordinate(10,0,0),1,Double.NaN,Collections.nCopies(8, 0.5), -1, PointPath.POINT_TYPE.DIFH));
+        points.add(new PointPath(new Coordinate(20,0,0),1,Double.NaN,Collections.nCopies(8, 0.5), -1, PointPath.POINT_TYPE.DIFH));
         points.add(new PointPath(new Coordinate(30,30,0),1,0,new double[0], -1, PointPath.POINT_TYPE.RECV));
         segments.add(new SegmentPath(1, flatTopography,new Coordinate(0,0,0)));
         segments.add(new SegmentPath(1, flatTopography,new Coordinate(0,0,0)));
@@ -80,8 +80,8 @@ public class PropagationPath_Cnossos {
         List<SegmentPath> srPath = new ArrayList<SegmentPath>();
         Vector3D flatTopography = new Vector3D(new Coordinate(0,0,0),new Coordinate(0,0,0));
 
-        points.add(new PointPath(new Coordinate(0,0,1),0,0,Double.NaN, -1, PointPath.POINT_TYPE.SRCE));
-        points.add(new PointPath(new Coordinate(200,0,4),0,0,Double.NaN, -1, PointPath.POINT_TYPE.RECV));
+        points.add(new PointPath(new Coordinate(0,0,1),0,0,new ArrayList<>(), -1, PointPath.POINT_TYPE.SRCE));
+        points.add(new PointPath(new Coordinate(200,0,4),0,0,new ArrayList<>(), -1, PointPath.POINT_TYPE.RECV));
         segments.add(new SegmentPath(0, flatTopography,new Coordinate(0,0,0)));
         srPath.add(new SegmentPath(0,flatTopography,new Coordinate(0,0,0)));
 
@@ -108,8 +108,8 @@ public class PropagationPath_Cnossos {
         List<SegmentPath> srPath = new ArrayList<SegmentPath>();
         Vector3D flatTopography = new Vector3D(new Coordinate(0,0,0),new Coordinate(200,0,0));
 
-        points.add(new PointPath(new Coordinate(0, 0, 0.05), 0, 0, Double.NaN, -1, PointPath.POINT_TYPE.SRCE));
-        points.add(new PointPath(new Coordinate(200, 0, 4), 0, 0, Double.NaN, -1, PointPath.POINT_TYPE.RECV));
+        points.add(new PointPath(new Coordinate(0, 0, 0.05), 0, 0, new ArrayList<>(), -1, PointPath.POINT_TYPE.SRCE));
+        points.add(new PointPath(new Coordinate(200, 0, 4), 0, 0, new ArrayList<>(), -1, PointPath.POINT_TYPE.RECV));
         srPath.add(new SegmentPath(1,flatTopography,new Coordinate(0,0,0)));
 
         PropagationPath propagationPath = new PropagationPath(false,points,segments, srPath);
@@ -133,8 +133,8 @@ public class PropagationPath_Cnossos {
         List<SegmentPath> srPath = new ArrayList<SegmentPath>();
         Vector3D flatTopography = new Vector3D(new Coordinate(0,0,0),new Coordinate(200,0,0));
 
-        points.add(new PointPath(new Coordinate(0, 0, 0.05), 0, 0, Double.NaN, -1, PointPath.POINT_TYPE.SRCE));
-        points.add(new PointPath(new Coordinate(200, 0, 4), 0, 0, Double.NaN, -1, PointPath.POINT_TYPE.RECV));
+        points.add(new PointPath(new Coordinate(0, 0, 0.05), 0, 0, new ArrayList<>(), -1, PointPath.POINT_TYPE.SRCE));
+        points.add(new PointPath(new Coordinate(200, 0, 4), 0, 0, new ArrayList<>(), -1, PointPath.POINT_TYPE.RECV));
         srPath.add(new SegmentPath(1,flatTopography,new Coordinate(0,0,0)));
 
         PropagationPath propagationPath = new PropagationPath(true,points,segments, srPath);
@@ -158,8 +158,8 @@ public class PropagationPath_Cnossos {
         List<SegmentPath> srPath = new ArrayList<SegmentPath>();
         Vector3D flatTopography = new Vector3D(new Coordinate(0,0,0),new Coordinate(200,0,0));
 
-        points.add(new PointPath(new Coordinate(0, 0, 0.05), 0.0, 0, Double.NaN, -1, PointPath.POINT_TYPE.SRCE));
-        points.add(new PointPath(new Coordinate(200, 0, 4.), 0., 0, Double.NaN, -1, PointPath.POINT_TYPE.RECV));
+        points.add(new PointPath(new Coordinate(0, 0, 0.05), 0.0, 0, new ArrayList<>(), -1, PointPath.POINT_TYPE.SRCE));
+        points.add(new PointPath(new Coordinate(200, 0, 4.), 0., 0, new ArrayList<>(), -1, PointPath.POINT_TYPE.RECV));
         srPath.add(new SegmentPath(0.7,flatTopography,new Coordinate(0,0,0)));
 
         PropagationPath propagationPath = new PropagationPath(true,points,segments, srPath);
@@ -184,8 +184,8 @@ public class PropagationPath_Cnossos {
         List<SegmentPath> srPath = new ArrayList<SegmentPath>();
         Vector3D flatTopography = new Vector3D(new Coordinate(0,0,0),new Coordinate(200,0,0));
 
-        points.add(new PointPath(new Coordinate(0, 0, 0.05), 0., 0, Double.NaN, -1, PointPath.POINT_TYPE.SRCE));
-        points.add(new PointPath(new Coordinate(200, 0, 4.), 0., 0, Double.NaN, -1, PointPath.POINT_TYPE.RECV));
+        points.add(new PointPath(new Coordinate(0, 0, 0.05), 0., 0, new ArrayList<>(), -1, PointPath.POINT_TYPE.SRCE));
+        points.add(new PointPath(new Coordinate(200, 0, 4.), 0., 0, new ArrayList<>(), -1, PointPath.POINT_TYPE.RECV));
         srPath.add(new SegmentPath(0.7,flatTopography,new Coordinate(0,0,0)));
 
         PropagationPath propagationPath = new PropagationPath(false,points,segments, srPath);
@@ -214,10 +214,10 @@ public class PropagationPath_Cnossos {
         List<SegmentPath> srPath = new ArrayList<SegmentPath>();
         Vector3D flatTopography = new Vector3D(new Coordinate(0,0,0),new Coordinate(150,0,0));
 
-        points.add(new PointPath(new Coordinate(0, 0, 0.05), 0, 0, Double.NaN, -1, PointPath.POINT_TYPE.SRCE));
-        points.add(new PointPath(new Coordinate(50, 0, 10.0), 0, 0, Double.NaN, -1, PointPath.POINT_TYPE.DIFH));
-        points.add(new PointPath(new Coordinate(100, 0, 10.0), 0, 0, Double.NaN, -1, PointPath.POINT_TYPE.DIFH));
-        points.add(new PointPath(new Coordinate(150, 0, 2.0), 0, 0, Double.NaN, -1, PointPath.POINT_TYPE.RECV));
+        points.add(new PointPath(new Coordinate(0, 0, 0.05), 0, 0, new ArrayList<>(), -1, PointPath.POINT_TYPE.SRCE));
+        points.add(new PointPath(new Coordinate(50, 0, 10.0), 0, 0, new ArrayList<>(), -1, PointPath.POINT_TYPE.DIFH));
+        points.add(new PointPath(new Coordinate(100, 0, 10.0), 0, 0, new ArrayList<>(), -1, PointPath.POINT_TYPE.DIFH));
+        points.add(new PointPath(new Coordinate(150, 0, 2.0), 0, 0, new ArrayList<>(), -1, PointPath.POINT_TYPE.RECV));
         // only first and last segment are necessary, even if it is possible to add more.
         segments.add(new SegmentPath(0, flatTopography,new Coordinate(0,0,0)));
         segments.add(new SegmentPath(0, flatTopography,new Coordinate(0,0,0)));
@@ -248,10 +248,10 @@ public class PropagationPath_Cnossos {
         List<SegmentPath> srPath = new ArrayList<SegmentPath>();
         Vector3D flatTopography = new Vector3D(new Coordinate(0,0,0),new Coordinate(150,0,0));
 
-        points.add(new PointPath(new Coordinate(0, 0, 0.05), 0, 0, Double.NaN, -1, PointPath.POINT_TYPE.SRCE));
-        points.add(new PointPath(new Coordinate(50, 0, 10.0), 0, 0, Double.NaN, -1, PointPath.POINT_TYPE.DIFH));
-        points.add(new PointPath(new Coordinate(100, 0, 10.0), 0, 0, Double.NaN, -1, PointPath.POINT_TYPE.DIFH));
-        points.add(new PointPath(new Coordinate(150, 0, 2.0), 0, 0, Double.NaN, -1, PointPath.POINT_TYPE.RECV));
+        points.add(new PointPath(new Coordinate(0, 0, 0.05), 0, 0, new ArrayList<>(), -1, PointPath.POINT_TYPE.SRCE));
+        points.add(new PointPath(new Coordinate(50, 0, 10.0), 0, 0, new ArrayList<>(), -1, PointPath.POINT_TYPE.DIFH));
+        points.add(new PointPath(new Coordinate(100, 0, 10.0), 0, 0, new ArrayList<>(), -1, PointPath.POINT_TYPE.DIFH));
+        points.add(new PointPath(new Coordinate(150, 0, 2.0), 0, 0, new ArrayList<>(), -1, PointPath.POINT_TYPE.RECV));
         // only first and last segment are necessary, even if it is possible to add more.
         segments.add(new SegmentPath(0.0, flatTopography,new Coordinate(0,0,0)));
         segments.add(new SegmentPath(0.0, flatTopography,new Coordinate(0,0,0)));
@@ -283,8 +283,8 @@ public class PropagationPath_Cnossos {
         List<SegmentPath> srPath = new ArrayList<SegmentPath>();
         Vector3D smallSlope = new Vector3D(new Coordinate(0,0,0),new Coordinate(150,0,2));
 
-        points.add(new PointPath(new Coordinate(0, 0, 0.05), 0, 0, Double.NaN, -1, PointPath.POINT_TYPE.SRCE));
-        points.add(new PointPath(new Coordinate(150, 0, 10.0), 0, 0, Double.NaN, -1, PointPath.POINT_TYPE.RECV));
+        points.add(new PointPath(new Coordinate(0, 0, 0.05), 0, 0, new ArrayList<>(), -1, PointPath.POINT_TYPE.SRCE));
+        points.add(new PointPath(new Coordinate(150, 0, 10.0), 0, 0, new ArrayList<>(), -1, PointPath.POINT_TYPE.RECV));
         // only first and last segment are necessary, even if it is possible to add more.
         srPath.add(new SegmentPath(0.7,smallSlope,new Coordinate(0,0,0)));
 
@@ -312,8 +312,8 @@ public class PropagationPath_Cnossos {
         List<SegmentPath> srPath = new ArrayList<SegmentPath>();
         Vector3D smallSlope = new Vector3D(new Coordinate(0,0,0),new Coordinate(150,0,2));
 
-        points.add(new PointPath(new Coordinate(0, 0, 0.05), 0, 0, Double.NaN, -1, PointPath.POINT_TYPE.SRCE));
-        points.add(new PointPath(new Coordinate(150, 0, 10.0), 0, 0, Double.NaN, -1, PointPath.POINT_TYPE.RECV));
+        points.add(new PointPath(new Coordinate(0, 0, 0.05), 0, 0, new ArrayList<>(), -1, PointPath.POINT_TYPE.SRCE));
+        points.add(new PointPath(new Coordinate(150, 0, 10.0), 0, 0, new ArrayList<>(), -1, PointPath.POINT_TYPE.RECV));
         // only first and last segment are necessary, even if it is possible to add more.
         srPath.add(new SegmentPath(0.7,smallSlope,new Coordinate(0,0,0)));
 
@@ -341,9 +341,9 @@ public class PropagationPath_Cnossos {
         List<SegmentPath> srPath = new ArrayList<SegmentPath>();
         Vector3D flatTopography = new Vector3D(new Coordinate(0,0,0),new Coordinate(150,0,0));
 
-        points.add(new PointPath(new Coordinate(0, 0, 4), 0, 0, Double.NaN, -1, PointPath.POINT_TYPE.SRCE));
-        points.add(new PointPath(new Coordinate(75, 20, 4), 0, Double.NaN, 0.3, -1, PointPath.POINT_TYPE.REFL));
-        points.add(new PointPath(new Coordinate(150, 0, 4), 0, 0, Double.NaN, -1, PointPath.POINT_TYPE.RECV));
+        points.add(new PointPath(new Coordinate(0, 0, 4), 0, 0, new ArrayList<>(), -1, PointPath.POINT_TYPE.SRCE));
+        points.add(new PointPath(new Coordinate(75, 20, 4), 0, Double.NaN, Collections.nCopies(8, 0.3), -1, PointPath.POINT_TYPE.REFL));
+        points.add(new PointPath(new Coordinate(150, 0, 4), 0, 0, new ArrayList<>(), -1, PointPath.POINT_TYPE.RECV));
         // only first and last segment are necessary, even if it is possible to add more.
         srPath.add(new SegmentPath(0.,flatTopography,new Coordinate(0,0,0)));
 
@@ -376,8 +376,8 @@ public class PropagationPath_Cnossos {
         List<SegmentPath> srPath = new ArrayList<SegmentPath>();
 
         Vector3D flatTopography = new Vector3D(new Coordinate(10,10,0),new Coordinate(200,50,0));
-        points.add(new PointPath(new Coordinate(10, 10, 1), 0, 0, Double.NaN, -1, PointPath.POINT_TYPE.SRCE));
-        points.add(new PointPath(new Coordinate(200, 50, 4), 0, 0, Double.NaN, -1, PointPath.POINT_TYPE.RECV));
+        points.add(new PointPath(new Coordinate(10, 10, 1), 0, 0, new ArrayList<>(), -1, PointPath.POINT_TYPE.SRCE));
+        points.add(new PointPath(new Coordinate(200, 50, 4), 0, 0, new ArrayList<>(), -1, PointPath.POINT_TYPE.RECV));
         segments.add(new SegmentPath(0, flatTopography,new Coordinate(0,0,0)));
         srPath.add(new SegmentPath(0,flatTopography,new Coordinate(0,0,0)));
 
@@ -404,8 +404,8 @@ public class PropagationPath_Cnossos {
         List<SegmentPath> srPath = new ArrayList<SegmentPath>();
         Vector3D flatTopography = new Vector3D(new Coordinate(10,10,0),new Coordinate(200,50,0));
 
-        points.add(new PointPath(new Coordinate(10, 10, 1), 0, 0, Double.NaN, -1, PointPath.POINT_TYPE.SRCE));
-        points.add(new PointPath(new Coordinate(200, 50, 4), 0, 0, Double.NaN, -1, PointPath.POINT_TYPE.RECV));
+        points.add(new PointPath(new Coordinate(10, 10, 1), 0, 0, new ArrayList<>(), -1, PointPath.POINT_TYPE.SRCE));
+        points.add(new PointPath(new Coordinate(200, 50, 4), 0, 0, new ArrayList<>(), -1, PointPath.POINT_TYPE.RECV));
         segments.add(new SegmentPath(0, flatTopography,new Coordinate(0,0,0)));
         srPath.add(new SegmentPath(0,flatTopography,new Coordinate(0,0,0)));
 
@@ -435,9 +435,9 @@ public class PropagationPath_Cnossos {
         List<SegmentPath> segments = new ArrayList<SegmentPath>();
         List<SegmentPath> srPath = new ArrayList<SegmentPath>();
 
-        points.add(new PointPath(new Coordinate(10, 10, 4.0), 0, 0, Double.NaN, -1, PointPath.POINT_TYPE.SRCE));
-        points.add(new PointPath(new Coordinate(175, 50, 4.0), 0, 0, Double.NaN, -1, PointPath.POINT_TYPE.DIFV));
-        points.add(new PointPath(new Coordinate(200, 10, 4.0), 0, 0, Double.NaN, -1, PointPath.POINT_TYPE.RECV));
+        points.add(new PointPath(new Coordinate(10, 10, 4.0), 0, 0, new ArrayList<>(), -1, PointPath.POINT_TYPE.SRCE));
+        points.add(new PointPath(new Coordinate(175, 50, 4.0), 0, 0, new ArrayList<>(), -1, PointPath.POINT_TYPE.DIFV));
+        points.add(new PointPath(new Coordinate(200, 10, 4.0), 0, 0, new ArrayList<>(), -1, PointPath.POINT_TYPE.RECV));
         // only first and last segment are necessary, even if it is possible to add more.
         segments.add(new SegmentPath(0.0, new Vector3D(new Coordinate(10,10,0),new Coordinate(175,50,0)),new Coordinate(0,0,0)));
         segments.add(new SegmentPath(0.0, new Vector3D(new Coordinate(175,50,0),new Coordinate(200,10,0)),new Coordinate(0,0,0)));

--- a/noisemodelling-propagation/src/test/java/org/noise_planet/noisemodelling/propagation/TestComputeRays.java
+++ b/noisemodelling-propagation/src/test/java/org/noise_planet/noisemodelling/propagation/TestComputeRays.java
@@ -28,10 +28,7 @@ import java.io.DataOutputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Random;
+import java.util.*;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -293,7 +290,7 @@ public class TestComputeRays {
         List<PropagationPath> expected = new ArrayList<>();
         expected.add(new PropagationPath(true,
                 Arrays.asList(new PointPath(
-                        new Coordinate(1,2,3), 15.0, 1, 0.23, 8,
+                        new Coordinate(1,2,3), 15.0, 1, Collections.nCopies(8, 0.23), 8,
                         PointPath.POINT_TYPE.RECV)),
                 Arrays.asList(new SegmentPath(0.15,
                         new org.locationtech.jts.math.Vector3D(1,1,1),
@@ -305,7 +302,7 @@ public class TestComputeRays {
                         new Coordinate(1.5,2.5,3.5)))));
         expected.add(new PropagationPath(true,
                 Arrays.asList(new PointPath(
-                        new Coordinate(2,7,1), 1.0, 0.5, 0.4, 1,
+                        new Coordinate(2,7,1), 1.0, 0.5, Collections.nCopies(8,0.4), 1,
                         PointPath.POINT_TYPE.DIFV)),
                 Arrays.asList(new SegmentPath(0.115,
                         new org.locationtech.jts.math.Vector3D(11,13,14),

--- a/noisemodelling-propagation/src/test/java/org/noise_planet/noisemodelling/propagation/jdbc/PointNoiseMapTest.java
+++ b/noisemodelling-propagation/src/test/java/org/noise_planet/noisemodelling/propagation/jdbc/PointNoiseMapTest.java
@@ -164,6 +164,11 @@ public class PointNoiseMapTest {
         public PropagationProcessData create(FastObstructionTest freeFieldFinder) {
             return new DirectPropagationProcessData(freeFieldFinder);
         }
+
+        @Override
+        public void initialize(Connection connection, PointNoiseMap pointNoiseMap) {
+
+        }
     }
 
     private static class JDBCComputeRaysOut implements PointNoiseMap.IComputeRaysOutFactory {

--- a/noisemodelling-tutorial-01/src/test/java/org/noise_planet/nmtutorial01/PostgisTest.java
+++ b/noisemodelling-tutorial-01/src/test/java/org/noise_planet/nmtutorial01/PostgisTest.java
@@ -161,7 +161,7 @@ public class PostgisTest {
                 assertEquals(nbReceivers, rs.getInt(1));
             }
         } catch (PSQLException ex) {
-            if (ex.getCause() instanceof ConnectException) {
+            if (ex.getCause() == null || ex.getCause() instanceof ConnectException) {
                 // Connection issue ignore
                 LOGGER.warn("Connection error to local PostGIS, ignored", ex);
             } else {

--- a/wps_scripts/src/main/groovy/org/noise_planet/noisemodelling/wps/Dynamic_Tools/Traffic_Probabilistic_Modelling.groovy
+++ b/wps_scripts/src/main/groovy/org/noise_planet/noisemodelling/wps/Dynamic_Tools/Traffic_Probabilistic_Modelling.groovy
@@ -765,6 +765,11 @@ class WpsPropagationProcessDataProbaFactory implements PointNoiseMap.Propagation
     PropagationProcessData create(FastObstructionTest freeFieldFinder) {
         return new WpsPropagationProcessDataProba(freeFieldFinder)
     }
+
+    @Override
+    void initialize(Connection connection, PointNoiseMap pointNoiseMap) throws SQLException {
+
+    }
 }
 
 

--- a/wps_scripts/src/main/groovy/org/noise_planet/noisemodelling/wps/Dynamic_Tools/Traffic_Probabilistic_Modelling.groovy
+++ b/wps_scripts/src/main/groovy/org/noise_planet/noisemodelling/wps/Dynamic_Tools/Traffic_Probabilistic_Modelling.groovy
@@ -467,6 +467,8 @@ def exec(Connection connection, input) {
  * Read source database and compute the sound emission spectrum of roads sources
  * */
 class WpsPropagationProcessDataProba extends PropagationProcessData {
+    static List<Integer> freq_lvl = Arrays.asList(PropagationProcessPathData.asOctaveBands(PropagationProcessPathData.DEFAULT_FREQUENCIES_THIRD_OCTAVE));
+
     // Lden values
     public List<double[]> wjSourcesD = new ArrayList<>()
     public List<double[]> wjSourcesE = new ArrayList<>()
@@ -498,10 +500,10 @@ class WpsPropagationProcessDataProba extends PropagationProcessData {
     double[][] computeLw(String Format, SpatialResultSet rs) throws SQLException {
 
         // Compute day average level
-        double[] ld = new double[PropagationProcessPathData.freq_lvl.size()]
-        double[] le = new double[PropagationProcessPathData.freq_lvl.size()]
-        double[] ln = new double[PropagationProcessPathData.freq_lvl.size()]
-        double[] lden = new double[PropagationProcessPathData.freq_lvl.size()]
+        double[] ld = new double[freq_lvl.size()]
+        double[] le = new double[freq_lvl.size()]
+        double[] ln = new double[freq_lvl.size()]
+        double[] lden = new double[freq_lvl.size()]
 
         if (Format == 'Proba') {
             double val = ComputeRays.dbaToW((BigDecimal) 90.0)
@@ -568,7 +570,7 @@ class WpsPropagationProcessDataProba extends PropagationProcessData {
 
             // Day
             int idFreq = 0
-            for (int freq : PropagationProcessPathData.freq_lvl) {
+            for (int freq : freq_lvl) {
                 RSParametersCnossos rsParametersCnossos = new RSParametersCnossos(lvSpeedD, hvSpeedD, hvSpeedD, lvSpeedD,
                         lvSpeedD, Math.max(0, tvD - hvD), 0, hvD, 0, 0, freq, Temperature,
                         pavement, Ts_stud, Pm_stud, Junc_dist, Junc_type)
@@ -577,7 +579,7 @@ class WpsPropagationProcessDataProba extends PropagationProcessData {
 
             // Evening
             idFreq = 0
-            for (int freq : PropagationProcessPathData.freq_lvl) {
+            for (int freq : freq_lvl) {
                 RSParametersCnossos rsParametersCnossos = new RSParametersCnossos(lvSpeedE, hvSpeedE, hvSpeedE, lvSpeedE,
                         lvSpeedE, Math.max(0, tvE - hvE), 0, hvE, 0, 0, freq, Temperature,
                         pavement, Ts_stud, Pm_stud, Junc_dist, Junc_type)
@@ -586,7 +588,7 @@ class WpsPropagationProcessDataProba extends PropagationProcessData {
 
             // Night
             idFreq = 0
-            for (int freq : PropagationProcessPathData.freq_lvl) {
+            for (int freq : freq_lvl) {
                 RSParametersCnossos rsParametersCnossos = new RSParametersCnossos(lvSpeedN, hvSpeedN, hvSpeedN, lvSpeedN,
                         lvSpeedN, Math.max(0, tvN - hvN), 0, hvN, 0, 0, freq, Temperature,
                         pavement, Ts_stud, Pm_stud, Junc_dist, Junc_type)
@@ -694,7 +696,7 @@ class WpsPropagationProcessDataProba extends PropagationProcessData {
                 lvPerHour = tmja * (1 - HV_PERCENTAGE) * (lv_hourly_distribution[h] / 100.0);
                 hgvPerHour = tmja * HV_PERCENTAGE * (hv_hourly_distribution[h] / 100.0);
                 int idFreq = 0;
-                for (int freq : PropagationProcessPathData.freq_lvl) {
+                for (int freq : freq_lvl) {
                     RSParametersCnossos rsParametersCnossos = new RSParametersCnossos(speedLv, speedMv, speedHgv, speedWav,
                             speedWbv, lvPerHour, mvPerHour, hgvPerHour, wavPerHour, wbvPerHour, freq, Temperature,
                             roadSurface, Ts_stud, Pm_stud, Junc_dist, Junc_type);
@@ -712,7 +714,7 @@ class WpsPropagationProcessDataProba extends PropagationProcessData {
                 lvPerHour = tmja * (1 - HV_PERCENTAGE) * (lv_hourly_distribution[h] / 100.0)
                 mvPerHour = tmja * HV_PERCENTAGE * (hv_hourly_distribution[h] / 100.0)
                 int idFreq = 0
-                for (int freq : PropagationProcessPathData.freq_lvl) {
+                for (int freq : freq_lvl) {
                     RSParametersCnossos rsParametersCnossos = new RSParametersCnossos(speedLv, speedMv, speedHgv, speedWav,
                             speedWbv, lvPerHour, mvPerHour, hgvPerHour, wavPerHour, wbvPerHour, freq, Temperature,
                             roadSurface, Ts_stud, Pm_stud, Junc_dist, Junc_type);
@@ -730,7 +732,7 @@ class WpsPropagationProcessDataProba extends PropagationProcessData {
                 lvPerHour = tmja * (1 - HV_PERCENTAGE) * (lv_hourly_distribution[h] / 100.0)
                 mvPerHour = tmja * HV_PERCENTAGE * (hv_hourly_distribution[h] / 100.0)
                 int idFreq = 0
-                for (int freq : PropagationProcessPathData.freq_lvl) {
+                for (int freq : freq_lvl) {
                     RSParametersCnossos rsParametersCnossos = new RSParametersCnossos(speedLv, speedMv, speedHgv, speedWav,
                             speedWbv, lvPerHour, mvPerHour, hgvPerHour, wavPerHour, wbvPerHour, freq, Temperature,
                             roadSurface, Ts_stud, Pm_stud, Junc_dist, Junc_type);
@@ -745,7 +747,7 @@ class WpsPropagationProcessDataProba extends PropagationProcessData {
 
         int idFreq = 0
         // Combine day evening night sound levels
-        for (int freq : PropagationProcessPathData.freq_lvl) {
+        for (int freq : freq_lvl) {
             lden[idFreq++] = (12 * ld[idFreq] + 4 * ComputeRays.dbaToW(ComputeRays.wToDba(le[idFreq]) + 5) + 8 * ComputeRays.dbaToW(ComputeRays.wToDba(ln[idFreq]) + 10)) / 24.0
         }
 

--- a/wps_scripts/src/main/groovy/org/noise_planet/noisemodelling/wps/Experimental/Drone_Dynamic_map.groovy
+++ b/wps_scripts/src/main/groovy/org/noise_planet/noisemodelling/wps/Experimental/Drone_Dynamic_map.groovy
@@ -135,6 +135,7 @@ class DroneProcessData {
 /** Read source database and compute the sound emission spectrum of roads sources **/
 @CompileStatic
 class DronePropagationProcessData extends PropagationProcessData {
+    static List<Integer> freq_lvl = Arrays.asList(PropagationProcessPathData.asOctaveBands(PropagationProcessPathData.DEFAULT_FREQUENCIES_THIRD_OCTAVE));
 
     protected List<double[]> wjSourcesD = new ArrayList<>()
 
@@ -157,7 +158,7 @@ class DronePropagationProcessData extends PropagationProcessData {
         double db_m4000 = 90
         double db_m8000 = 90
 
-        double[] res_d = new double[PropagationProcessPathData.freq_lvl.size()]
+        double[] res_d = new double[freq_lvl.size()]
 
         res_d = [db_m63, db_m125, db_m250, db_m500, db_m1000, db_m2000, db_m4000, db_m8000]
 
@@ -177,6 +178,11 @@ class DronePropagationProcessDataFactory implements PointNoiseMap.PropagationPro
     @Override
     PropagationProcessData create(FastObstructionTest freeFieldFinder) {
         return new DronePropagationProcessData(freeFieldFinder)
+    }
+
+    @Override
+    void initialize(Connection connection, PointNoiseMap pointNoiseMap) throws SQLException {
+
     }
 }
 

--- a/wps_scripts/src/main/groovy/org/noise_planet/noisemodelling/wps/Experimental/Dynamic_map.groovy
+++ b/wps_scripts/src/main/groovy/org/noise_planet/noisemodelling/wps/Experimental/Dynamic_map.groovy
@@ -86,6 +86,7 @@ class DynamicProcessData {
 /** Read source database and compute the sound emission spectrum of roads sources **/
 @CompileStatic
 class DynamicPropagationProcessData extends PropagationProcessData {
+    static List<Integer> freq_lvl = Arrays.asList(PropagationProcessPathData.asOctaveBands(PropagationProcessPathData.DEFAULT_FREQUENCIES_THIRD_OCTAVE));
 
     protected List<double[]> wjSourcesD = new ArrayList<>()
 
@@ -110,7 +111,7 @@ class DynamicPropagationProcessData extends PropagationProcessData {
         int t = rs.getInt("T")
         int id = rs.getInt("ID")
 
-        double[] res_d = new double[PropagationProcessPathData.freq_lvl.size()]
+        double[] res_d = new double[freq_lvl.size()]
 
         res_d = [db_m63,db_m125,db_m250,db_m500,db_m1000,db_m2000,db_m4000,db_m8000]
 
@@ -131,6 +132,11 @@ class DynamicPropagationProcessDataFactory implements PointNoiseMap.PropagationP
     @Override
     PropagationProcessData create(FastObstructionTest freeFieldFinder) {
         return new DynamicPropagationProcessData(freeFieldFinder)
+    }
+
+    @Override
+    void initialize(Connection connection, PointNoiseMap pointNoiseMap) throws SQLException {
+
     }
 }
 

--- a/wps_scripts/src/main/groovy/org/noise_planet/noisemodelling/wps/Experimental/Get_Rayz.groovy
+++ b/wps_scripts/src/main/groovy/org/noise_planet/noisemodelling/wps/Experimental/Get_Rayz.groovy
@@ -721,6 +721,11 @@ class TrafficRayzPropagationProcessDataFactory implements PointNoiseMap.Propagat
     PropagationProcessData create(FastObstructionTest freeFieldFinder) {
         return new TrafficRayzPropagationProcessData(freeFieldFinder);
     }
+
+    @Override
+    void initialize(Connection connection, PointNoiseMap pointNoiseMap) throws SQLException {
+
+    }
 }
 
 /**
@@ -729,6 +734,7 @@ class TrafficRayzPropagationProcessDataFactory implements PointNoiseMap.Propagat
 @CompileStatic
 class TrafficRayzPropagationProcessData extends PropagationProcessData {
     // Lden values
+    static List<Integer> freq_lvl = Arrays.asList(PropagationProcessPathData.asOctaveBands(PropagationProcessPathData.DEFAULT_FREQUENCIES_THIRD_OCTAVE));
     public List<double[]> wjSourcesDEN = new ArrayList<>()
     //public Map<Long, Integer> SourcesPk = new HashMap<>()
 
@@ -767,9 +773,9 @@ class TrafficRayzPropagationProcessData extends PropagationProcessData {
         String pavement = rs.getString("PVMT")
 
         // Compute day average level
-        double[] ld = new double[PropagationProcessPathData.freq_lvl.size()];
-        double[] le = new double[PropagationProcessPathData.freq_lvl.size()];
-        double[] ln = new double[PropagationProcessPathData.freq_lvl.size()];
+        double[] ld = new double[freq_lvl.size()];
+        double[] le = new double[freq_lvl.size()];
+        double[] ln = new double[freq_lvl.size()];
 
         double Temperature = 20.0d
         double Ts_stud = 0
@@ -779,7 +785,7 @@ class TrafficRayzPropagationProcessData extends PropagationProcessData {
 
 
         int idFreq = 0
-        for (int freq : PropagationProcessPathData.freq_lvl) {
+        for (int freq : freq_lvl) {
             RSParametersCnossos rsParametersCnossos = new RSParametersCnossos(lvSpeedD, hvSpeedD, hvSpeedD, lvSpeedD,
                     lvSpeedD, Math.max(0, tvD - hvD), hvD, 0, 0, 0, freq, Temperature,
                     pavement, Ts_stud, Pm_stud, Junc_dist, Junc_type)
@@ -789,7 +795,7 @@ class TrafficRayzPropagationProcessData extends PropagationProcessData {
 
 
         idFreq = 0
-        for (int freq : PropagationProcessPathData.freq_lvl) {
+        for (int freq : freq_lvl) {
             RSParametersCnossos rsParametersCnossos = new RSParametersCnossos(lvSpeedE, hvSpeedE, hvSpeedE, lvSpeedE,
                     lvSpeedE, Math.max(0, tvE - hvE), hvE, 0, 0, 0, freq, Temperature,
                     pavement, Ts_stud, Pm_stud, Junc_dist, Junc_type)
@@ -797,17 +803,17 @@ class TrafficRayzPropagationProcessData extends PropagationProcessData {
         }
 
         idFreq = 0
-        for (int freq : PropagationProcessPathData.freq_lvl) {
+        for (int freq : freq_lvl) {
             RSParametersCnossos rsParametersCnossos = new RSParametersCnossos(lvSpeedN, hvSpeedN, hvSpeedN, lvSpeedN,
                     lvSpeedN, Math.max(0, tvN - hvN), hvN, 0, 0, 0, freq, Temperature,
                     pavement, Ts_stud, Pm_stud, Junc_dist, Junc_type)
             ln[idFreq++] += EvaluateRoadSourceCnossos.evaluate(rsParametersCnossos)
         }
 
-        double[] lden = new double[PropagationProcessPathData.freq_lvl.size()]
+        double[] lden = new double[freq_lvl.size()]
 
         idFreq = 0
-        for (int freq : PropagationProcessPathData.freq_lvl) {
+        for (int freq : freq_lvl) {
             lden[idFreq++] = (12 * ld[idFreq] +
                     4 * ComputeRays.dbaToW(ComputeRays.wToDba(le[idFreq]) + 5) +
                     8 * ComputeRays.dbaToW(ComputeRays.wToDba(ln[idFreq]) + 10)) / 24.0

--- a/wps_scripts/src/main/groovy/org/noise_planet/noisemodelling/wps/Experimental/Multi_Runs.groovy
+++ b/wps_scripts/src/main/groovy/org/noise_planet/noisemodelling/wps/Experimental/Multi_Runs.groovy
@@ -690,7 +690,8 @@ class MRComputeRaysOut extends ComputeRaysOut {
 
 @CompileStatic
 class MREvaluateAttenuationCnossos extends EvaluateAttenuationCnossos {
-    //private int nbfreq;
+    static List<Integer> freq_lvl = Arrays.asList(PropagationProcessPathData.asOctaveBands(PropagationProcessPathData.DEFAULT_FREQUENCIES_THIRD_OCTAVE));
+
     private double[] freq_lambda
     private double[] aGlobal
     private final static double ONETHIRD = 1.0 / 3.0
@@ -733,9 +734,9 @@ class MREvaluateAttenuationCnossos extends EvaluateAttenuationCnossos {
     }
 
     static double[] getMRARef(MRPropagationPath path) {
-        double[] aRef = new double[PropagationProcessPathData.freq_lvl.size()]
+        double[] aRef = new double[freq_lvl.size()]
 
-        for (int idf = 0; idf < PropagationProcessPathData.freq_lvl.size(); ++idf) {
+        for (int idf = 0; idf < freq_lvl.size(); ++idf) {
             for (int idRef = 0; idRef < path.refPoints.size(); ++idRef) {
                 //List<Double> alpha = ((PointPath) path.getPointList().get((Integer) path.refPoints.get(idRef))).alphaWall
                 List<Double> alpha = ((PointPath) path.getPointList().get((Integer) path.refPoints.get(idRef))).alphaWall.collect {
@@ -750,13 +751,13 @@ class MREvaluateAttenuationCnossos extends EvaluateAttenuationCnossos {
 
 
     double[] evaluate(MRPropagationPath path, PropagationProcessPathData data) {
-        aGlobal = new double[PropagationProcessPathData.freq_lvl.size()]
-        freq_lambda = new double[PropagationProcessPathData.freq_lvl.size()]
-        double[] aRef = new double[PropagationProcessPathData.freq_lvl.size()]
+        aGlobal = new double[freq_lvl.size()]
+        freq_lambda = new double[freq_lvl.size()]
+        double[] aRef = new double[freq_lvl.size()]
 
-        for (int idf = 0; idf < PropagationProcessPathData.freq_lvl.size(); ++idf) {
-            if (PropagationProcessPathData.freq_lvl.get(idf) > 0) {
-                freq_lambda[idf] = data.getCelerity() / (double) (Integer) PropagationProcessPathData.freq_lvl.get(idf)
+        for (int idf = 0; idf < freq_lvl.size(); ++idf) {
+            if (freq_lvl.get(idf) > 0) {
+                freq_lambda[idf] = data.getCelerity() / (double) (Integer) freq_lvl.get(idf)
             } else {
                 freq_lambda[idf] = 1.0D
             }
@@ -778,7 +779,7 @@ class MREvaluateAttenuationCnossos extends EvaluateAttenuationCnossos {
             aRef = getMRARef(path)
         }
 
-        for (int idfreq = 0; idfreq < PropagationProcessPathData.freq_lvl.size(); ++idfreq) {
+        for (int idfreq = 0; idfreq < freq_lvl.size(); ++idfreq) {
             double aAtm;
             if (path.difVPoints.size() <= 0 && path.refPoints.size() <= 0) {
                 aAtm = getAAtm(((SegmentPath) path.getSRList().get(0)).d, alpha_atmo[idfreq]);

--- a/wps_scripts/src/main/groovy/org/noise_planet/noisemodelling/wps/NoiseModelling/Noise_level_from_source.groovy
+++ b/wps_scripts/src/main/groovy/org/noise_planet/noisemodelling/wps/NoiseModelling/Noise_level_from_source.groovy
@@ -185,9 +185,9 @@ def forgeCreateTable(Sql sql, String tableName, LDENConfig ldenConfig, String ge
         sb.append(" (IDRECEIVER bigint NOT NULL");
     }
     sb.append(", THE_GEOM geometry")
-    for (int idfreq = 0; idfreq < PropagationProcessPathData.freq_lvl.size(); idfreq++) {
+    for (int idfreq = 0; idfreq < ldenConfig.propagationProcessPathData.freq_lvl.size(); idfreq++) {
         sb.append(", HZ");
-        sb.append(PropagationProcessPathData.freq_lvl.get(idfreq));
+        sb.append(ldenConfig.propagationProcessPathData.freq_lvl.get(idfreq));
         sb.append(" numeric(5, 2)");
     }
     sb.append(", LAEQ numeric(5, 2), LEQ numeric(5, 2) ) AS SELECT PK");
@@ -196,9 +196,9 @@ def forgeCreateTable(Sql sql, String tableName, LDENConfig ldenConfig, String ge
     }
     sb.append(", ")
     sb.append(geomField)
-    for (int idfreq = 0; idfreq < PropagationProcessPathData.freq_lvl.size(); idfreq++) {
+    for (int idfreq = 0; idfreq < ldenConfig.propagationProcessPathData.freq_lvl.size(); idfreq++) {
         sb.append(", HZ");
-        sb.append(PropagationProcessPathData.freq_lvl.get(idfreq));
+        sb.append(ldenConfig.propagationProcessPathData.freq_lvl.get(idfreq));
     }
     sb.append(", LAEQ, LEQ FROM ")
     sb.append(tableReceiver)
@@ -409,18 +409,19 @@ def exec(Connection connection, input) {
     pointNoiseMap.setWallAbsorption(wall_alpha)
     pointNoiseMap.setThreadCount(n_thread)
 
-    // Do not propagate for low emission or far away sources
-    // Maximum error in dB
-    pointNoiseMap.setMaximumError(0.1d)
-    // Init Map
-    pointNoiseMap.initialize(connection, new EmptyProgressVisitor())
-
     // --------------------------------------------
     // Initialize NoiseModelling emission part
     // --------------------------------------------
 
     pointNoiseMap.setComputeRaysOutFactory(ldenProcessing)
     pointNoiseMap.setPropagationProcessDataFactory(ldenProcessing)
+
+
+    // Do not propagate for low emission or far away sources
+    // Maximum error in dB
+    pointNoiseMap.setMaximumError(0.1d)
+    // Init Map
+    pointNoiseMap.initialize(connection, new EmptyProgressVisitor())
 
     // --------------------------------------------
     // Run Calculations

--- a/wps_scripts/src/main/groovy/org/noise_planet/noisemodelling/wps/NoiseModelling/Noise_level_from_traffic.groovy
+++ b/wps_scripts/src/main/groovy/org/noise_planet/noisemodelling/wps/NoiseModelling/Noise_level_from_traffic.groovy
@@ -409,7 +409,7 @@ def exec(Connection connection, input) {
 
 
     // Set environmental parameters
-    PropagationProcessPathData environmentalData = new PropagationProcessPathData()
+    PropagationProcessPathData environmentalData = new PropagationProcessPathData(false)
 
     if(input.containsKey('confHumidity')) {
         environmentalData.setHumidity(input['confHumidity'] as Double)

--- a/wps_scripts/src/main/groovy/org/noise_planet/noisemodelling/wps/NoiseModelling/Noise_level_from_traffic.groovy
+++ b/wps_scripts/src/main/groovy/org/noise_planet/noisemodelling/wps/NoiseModelling/Noise_level_from_traffic.groovy
@@ -209,9 +209,9 @@ def forgeCreateTable(Sql sql, String tableName, LDENConfig ldenConfig, String ge
         sb.append(" (IDRECEIVER bigint NOT NULL");
     }
     sb.append(", THE_GEOM geometry")
-    for (int idfreq = 0; idfreq < PropagationProcessPathData.freq_lvl.size(); idfreq++) {
+    for (int idfreq = 0; idfreq < ldenConfig.propagationProcessPathData.freq_lvl.size(); idfreq++) {
         sb.append(", HZ");
-        sb.append(PropagationProcessPathData.freq_lvl.get(idfreq));
+        sb.append(ldenConfig.propagationProcessPathData.freq_lvl.get(idfreq));
         sb.append(" numeric(5, 2)");
     }
     sb.append(", LAEQ numeric(5, 2), LEQ numeric(5, 2) ) AS SELECT PK");
@@ -220,9 +220,9 @@ def forgeCreateTable(Sql sql, String tableName, LDENConfig ldenConfig, String ge
     }
     sb.append(", ")
     sb.append(geomField)
-    for (int idfreq = 0; idfreq < PropagationProcessPathData.freq_lvl.size(); idfreq++) {
+    for (int idfreq = 0; idfreq < ldenConfig.propagationProcessPathData.freq_lvl.size(); idfreq++) {
         sb.append(", HZ");
-        sb.append(PropagationProcessPathData.freq_lvl.get(idfreq));
+        sb.append(ldenConfig.propagationProcessPathData.freq_lvl.get(idfreq));
     }
     sb.append(", LAEQ, LEQ FROM ")
     sb.append(tableReceiver)
@@ -477,13 +477,16 @@ def exec(Connection connection, input) {
             // Run ray propagation
             System.println(String.format("Compute... %.3f %% (%d receivers in this cell)", 100 * k++ / cells.size(), cells.get(cellIndex)))
             IComputeRaysOut ro = pointNoiseMap.evaluateCell(connection, cellIndex.getLatitudeIndex(), cellIndex.getLongitudeIndex(), progressVisitor, receivers)
-            if(ro instanceof LDENComputeRaysOut) {
-                LDENPropagationProcessData ldenPropagationProcessData = (LDENPropagationProcessData)ro.inputData;
+            if (ro instanceof LDENComputeRaysOut) {
+                LDENPropagationProcessData ldenPropagationProcessData = (LDENPropagationProcessData) ro.inputData;
                 System.out.println(String.format("This computation area contains %d receivers %d sound sources and %d buildings",
                         ldenPropagationProcessData.receivers.size(), ldenPropagationProcessData.sourceGeometries.size(),
                         ldenPropagationProcessData.freeFieldFinder.getBuildingCount()));
             }
         }
+    } catch(IllegalArgumentException | IllegalStateException ex) {
+        System.err.println(ex);
+        throw ex;
     } finally {
         ldenProcessing.stop()
     }

--- a/wps_scripts/src/main/groovy/org/noise_planet/noisemodelling/wps/NoiseModelling/Road_Emission_from_Traffic.groovy
+++ b/wps_scripts/src/main/groovy/org/noise_planet/noisemodelling/wps/NoiseModelling/Road_Emission_from_Traffic.groovy
@@ -176,9 +176,11 @@ def exec(Connection connection, input) {
 
     // Get Class to compute LW
     LDENConfig ldenConfig = new LDENConfig(LDENConfig.INPUT_MODE.INPUT_MODE_TRAFFIC_FLOW)
+    ldenConfig.setPropagationProcessPathData(new PropagationProcessPathData(false));
+
+
     //TODO read DEM table for road slope impact on noise emission
     LDENPropagationProcessData ldenData =  new LDENPropagationProcessData(null, ldenConfig)
-
 
     // Get size of the table (number of road segments
     PreparedStatement st = connection.prepareStatement("SELECT COUNT(*) AS total FROM " + sources_table_name)


### PR DESCRIPTION
Update noisemodelling propagation in order to support for third octave and custom frequency bands selection.
When using LDENPointNoiseMapFactory, the source table fields are read and the calculation is made only on the specified frequencies . 