### PR TITLE
Diffraction on vertical edge is for point source only

### DIFF
--- a/wps_scripts/src/main/groovy/org/noise_planet/noisemodelling/wps/NoiseModelling/Noise_level_from_source.groovy
+++ b/wps_scripts/src/main/groovy/org/noise_planet/noisemodelling/wps/NoiseModelling/Noise_level_from_source.groovy
@@ -139,7 +139,7 @@ inputs = [
         confDiffVertical        : [
                 name       : 'Diffraction on vertical edges',
                 title      : 'Diffraction on vertical edges',
-                description: 'Compute or not the diffraction on vertical edges.' +
+                description: 'Compute or not the diffraction on vertical edges.Following Directive 2015/996, enable this option for rail and industrial sources only.' +
                         '</br> </br> <b> Default value : false </b>',
                 min        : 0, max: 1, type: Boolean.class
         ],

--- a/wps_scripts/src/main/groovy/org/noise_planet/noisemodelling/wps/NoiseModelling/Noise_level_from_traffic.groovy
+++ b/wps_scripts/src/main/groovy/org/noise_planet/noisemodelling/wps/NoiseModelling/Noise_level_from_traffic.groovy
@@ -160,7 +160,7 @@ inputs = [
         confDiffVertical        : [
                 name       : 'Diffraction on vertical edges',
                 title      : 'Diffraction on vertical edges',
-                description: 'Compute or not the diffraction on vertical edges.' +
+                description: 'Compute or not the diffraction on vertical edges.Following Directive 2015/996, enable this option for rail and industrial sources only.' +
                         '</br> </br> <b> Default value : false </b>',
                 min        : 0, max: 1,
                 type       : Boolean.class


### PR DESCRIPTION
Following Directive 2015/996, diffraction on vertical edge is for rail and industrial sources only.