### PR TITLE
Profiler release

### DIFF
--- a/noisemodelling-jdbc/src/main/java/org/noise_planet/noisemodelling/jdbc/LDENComputeRaysOut.java
+++ b/noisemodelling-jdbc/src/main/java/org/noise_planet/noisemodelling/jdbc/LDENComputeRaysOut.java
@@ -25,7 +25,7 @@ public class LDENComputeRaysOut extends ComputeRaysOutAttenuation {
 
 
     @Override
-    public IComputeRaysOut subProcess(int receiverStart, int receiverEnd) {
+    public IComputeRaysOut subProcess() {
         return new ThreadComputeRaysOut(this);
     }
 

--- a/noisemodelling-jdbc/src/main/java/org/noise_planet/noisemodelling/jdbc/LDENPointNoiseMapFactory.java
+++ b/noisemodelling-jdbc/src/main/java/org/noise_planet/noisemodelling/jdbc/LDENPointNoiseMapFactory.java
@@ -26,6 +26,7 @@ import org.h2gis.utilities.JDBCUtilities;
 import org.noise_planet.noisemodelling.emission.DirectionAttributes;
 import org.noise_planet.noisemodelling.emission.RailWayLW;
 import org.noise_planet.noisemodelling.pathfinder.*;
+import org.noise_planet.noisemodelling.pathfinder.utils.ProfilerThread;
 import org.noise_planet.noisemodelling.propagation.*;
 import org.noise_planet.noisemodelling.propagation.ComputeRaysOutAttenuation;
 import org.slf4j.Logger;
@@ -41,7 +42,7 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 /**
  *
  */
-public class LDENPointNoiseMapFactory implements PointNoiseMap.PropagationProcessDataFactory, PointNoiseMap.IComputeRaysOutFactory {
+public class LDENPointNoiseMapFactory implements PointNoiseMap.PropagationProcessDataFactory, PointNoiseMap.IComputeRaysOutFactory, ProfilerThread.Metric {
     LDENConfig ldenConfig;
     TableWriter tableWriter;
     Thread tableWriterThread;
@@ -57,6 +58,21 @@ public class LDENPointNoiseMapFactory implements PointNoiseMap.PropagationProces
     public LDENPointNoiseMapFactory(Connection connection, LDENConfig ldenConfig) {
         this.ldenConfig = ldenConfig;
         this.connection = connection;
+    }
+
+    @Override
+    public String[] getColumnNames() {
+        return new String[] {"jdbc_stack"};
+    }
+
+    @Override
+    public String[] getCurrentValues() {
+        return new String[] {Long.toString(ldenData.queueSize.get())};
+    }
+
+    @Override
+    public void tick(long currentMillis) {
+
     }
 
     public void insertTrainDirectivity() {

--- a/noisemodelling-jdbc/src/main/java/org/noise_planet/noisemodelling/jdbc/LDENPointNoiseMapFactory.java
+++ b/noisemodelling-jdbc/src/main/java/org/noise_planet/noisemodelling/jdbc/LDENPointNoiseMapFactory.java
@@ -310,7 +310,7 @@ public class LDENPointNoiseMapFactory implements PointNoiseMap.PropagationProces
                 sb.append(" (IDRECEIVER bigint NOT NULL");
                 sb.append(", IDSOURCE bigint NOT NULL");
             } else {
-                sb.append(" (IDRECEIVER bigint");
+                sb.append(" (IDRECEIVER bigint NOT NULL");
             }
             for (int idfreq = 0; idfreq < ldenConfig.propagationProcessPathData.freq_lvl.size(); idfreq++) {
                 sb.append(", HZ");

--- a/noisemodelling-jdbc/src/main/java/org/noise_planet/noisemodelling/jdbc/PointNoiseMap.java
+++ b/noisemodelling-jdbc/src/main/java/org/noise_planet/noisemodelling/jdbc/PointNoiseMap.java
@@ -19,6 +19,7 @@ import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.index.strtree.STRtree;
 import org.noise_planet.noisemodelling.pathfinder.ComputeRays;
+import org.noise_planet.noisemodelling.pathfinder.utils.ProfilerThread;
 import org.noise_planet.noisemodelling.propagation.ComputeRaysOutAttenuation;
 import org.noise_planet.noisemodelling.pathfinder.FastObstructionTest;
 import org.noise_planet.noisemodelling.pathfinder.IComputeRaysOut;
@@ -46,10 +47,30 @@ public class PointNoiseMap extends JdbcNoiseMap {
     private IComputeRaysOutFactory computeRaysOutFactory;
     private Logger logger = LoggerFactory.getLogger(PointNoiseMap.class);
     private int threadCount = 0;
+    private ProfilerThread profilerThread;
 
     public PointNoiseMap(String buildingsTableName, String sourcesTableName, String receiverTableName) {
         super(buildingsTableName, sourcesTableName);
         this.receiverTableName = receiverTableName;
+    }
+
+
+    /**
+     * Computation stacks and timing are collected by this class in order
+     * to profile the execution of the simulation
+     * @return Instance of ProfilerThread or null
+     */
+    public ProfilerThread getProfilerThread() {
+        return profilerThread;
+    }
+
+    /**
+     * Computation stacks and timing are collected by this class in order
+     * to profile the execution of the simulation
+     * @param profilerThread Instance of ProfilerThread
+     */
+    public void setProfilerThread(ProfilerThread profilerThread) {
+        this.profilerThread = profilerThread;
     }
 
     public void setComputeRaysOutFactory(IComputeRaysOutFactory computeRaysOutFactory) {
@@ -249,6 +270,10 @@ public class PointNoiseMap extends JdbcNoiseMap {
         }
 
         ComputeRays computeRays = new ComputeRays(threadData);
+
+        if(profilerThread != null) {
+            computeRays.setProfilerThread(profilerThread);
+        }
 
         if(threadCount > 0) {
             computeRays.setThreadCount(threadCount);

--- a/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/ComputeRays.java
+++ b/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/ComputeRays.java
@@ -379,6 +379,10 @@ public class ComputeRays {
         List<PropagationPath> reflexionPropagationPaths = new ArrayList<>();
 
         for (MirrorReceiverResult receiverReflection : receiverReflections) {
+            // Check propagation distance limitation
+            if(receiverReflection.getReceiverPos().distance3D(srcCoord) > data.maxSrcDist) {
+                break;
+            }
             // Print wall reflections
             //System.out.println(Arrays.toString(asWallArray(receiverReflection)));
             List<MirrorReceiverResult> rayPath = new ArrayList<>(data.reflexionOrder + 2);
@@ -392,6 +396,12 @@ public class ComputeRays {
             linters.computeIntersection(seg.p0, seg.p1,
                     receiverReflection.getReceiverPos(),
                     destinationPt);
+
+            // Check first wall distance reflection limitation
+            if(linters.hasIntersection() && new Coordinate(
+                    linters.getIntersection(0)).distance(srcCoord) > data.maxRefDist) {
+                break;
+            }
             while (linters.hasIntersection() && MirrorReceiverIterator.wallPointTest(seg, destinationPt)) {
                 // There are a probable reflection point on the segment
                 Coordinate reflectionPt = new Coordinate(

--- a/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/ComputeRaysOut.java
+++ b/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/ComputeRaysOut.java
@@ -89,7 +89,7 @@ public class ComputeRaysOut implements IComputeRaysOut {
     }
 
     @Override
-    public IComputeRaysOut subProcess(int receiverStart, int receiverEnd) {
+    public IComputeRaysOut subProcess() {
         return new ThreadRaysOut(this);
     }
 
@@ -183,8 +183,8 @@ public class ComputeRaysOut implements IComputeRaysOut {
     }
 
     @Override
-    public IComputeRaysOut subProcess(int receiverStart, int receiverEnd) {
-        return multiThreadParent.subProcess(receiverStart, receiverEnd);
+    public IComputeRaysOut subProcess() {
+        return multiThreadParent.subProcess();
     }
 }
 }

--- a/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/IComputeRaysOut.java
+++ b/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/IComputeRaysOut.java
@@ -19,9 +19,7 @@ public interface IComputeRaysOut {
     void finalizeReceiver(long receiverId);
     /**
      * If the implementation does not support thread concurrency, this method is called to return an instance
-     * @param receiverStart
-     * @param receiverEnd
      * @return
      */
-    IComputeRaysOut subProcess(int receiverStart, int receiverEnd);
+    IComputeRaysOut subProcess();
 }

--- a/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/MirrorReceiverIterator.java
+++ b/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/MirrorReceiverIterator.java
@@ -47,7 +47,6 @@ import java.util.*;
 public class MirrorReceiverIterator implements Iterator<MirrorReceiverResult> {
     private final Coordinate receiverCoord;
     private final List<FastObstructionTest.Wall> nearBuildingsWalls;
-    private final LineSegment srcReceiver;
     private final double distanceLimitation;
     private final double propagationLimitation;
     // Wall stack
@@ -55,11 +54,10 @@ public class MirrorReceiverIterator implements Iterator<MirrorReceiverResult> {
     private MirrorReceiverResult current = null;
     private final int maxDepth;
 
-    private MirrorReceiverIterator(Coordinate receiverCoord, List<FastObstructionTest.Wall> nearBuildingsWalls,
-                                  LineSegment srcReceiver, double distanceLimitation, int maxDepth, double propagationLimitation) {
+    private MirrorReceiverIterator(Coordinate receiverCoord, List<FastObstructionTest.Wall> nearBuildingsWalls
+            , double distanceLimitation, int maxDepth, double propagationLimitation) {
         this.receiverCoord = receiverCoord;
         this.nearBuildingsWalls = nearBuildingsWalls;
-        this.srcReceiver = srcReceiver;
         this.distanceLimitation = distanceLimitation;
         this.wallIdentifierIt = new CrossTableIterator(maxDepth, nearBuildingsWalls.size());
         this.propagationLimitation = propagationLimitation;
@@ -98,17 +96,12 @@ public class MirrorReceiverIterator implements Iterator<MirrorReceiverResult> {
             }
             if (isCCW) {
                 Coordinate intersectionPt = wall.project(receiverIm);
-                if (wall.distance(srcReceiver) < distanceLimitation) // Test maximum distance constraint
-                {
-                    Coordinate mirrored = new Coordinate(2 * intersectionPt.x
-                            - receiverIm.x, 2 * intersectionPt.y
-                            - receiverIm.y, receiverIm.z);
-                    if (srcReceiver.p0.distance(mirrored) < propagationLimitation) {
-                        next = new MirrorReceiverResult(mirrored,
-                                parent, wallId, wall.getBuildingId());
-                        break;
-                    }
-                }
+                Coordinate mirrored = new Coordinate(2 * intersectionPt.x
+                        - receiverIm.x, 2 * intersectionPt.y
+                        - receiverIm.y, receiverIm.z);
+                    next = new MirrorReceiverResult(mirrored,
+                            parent, wallId, wall.getBuildingId());
+                    break;
             }
             // MirrorReceiverResult has not been found with this wall
             // Do not fetch sub-reflections
@@ -178,16 +171,14 @@ public class MirrorReceiverIterator implements Iterator<MirrorReceiverResult> {
     public static final class It implements Iterable<MirrorReceiverResult> {
         private final Coordinate receiverCoord;
         private final List<FastObstructionTest.Wall> nearBuildingsWalls;
-        private final LineSegment srcReceiver;
         private final double distanceLimitation;
         private final int maxDepth;
         private final double propagationLimitation;
 
         public It(Coordinate receiverCoord, List<FastObstructionTest.Wall> nearBuildingsWalls,
-                  LineSegment srcReceiver, double distanceLimitation, int maxDepth, double propagationLimitation) {
+                  double distanceLimitation, int maxDepth, double propagationLimitation) {
             this.receiverCoord = receiverCoord;
             this.nearBuildingsWalls = nearBuildingsWalls;
-            this.srcReceiver = srcReceiver;
             this.distanceLimitation = distanceLimitation;
             this.maxDepth = maxDepth;
             this.propagationLimitation = propagationLimitation;
@@ -195,7 +186,7 @@ public class MirrorReceiverIterator implements Iterator<MirrorReceiverResult> {
 
         @Override
         public java.util.Iterator<MirrorReceiverResult> iterator() {
-            return new MirrorReceiverIterator(receiverCoord, nearBuildingsWalls, srcReceiver, distanceLimitation,
+            return new MirrorReceiverIterator(receiverCoord, nearBuildingsWalls, distanceLimitation,
                     maxDepth,propagationLimitation);
         }
     }

--- a/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/PropagationProcessData.java
+++ b/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/PropagationProcessData.java
@@ -55,7 +55,7 @@ import java.util.*;
  */
 public class PropagationProcessData {
     public static final double DEFAULT_MAX_PROPAGATION_DISTANCE = 1200;
-    public static final double DEFAULT_MAXIMUM_REF_DIST = 50;
+    public static final double DEFAULT_MAXIMUM_REF_DIST = 700;
     public static final double DEFAULT_RECEIVER_DIST = 1.0;
     public static final double DEFAULT_GS = 0.0;
     public static final String YAW_DATABASE_FIELD = "YAW";

--- a/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/utils/JVMMemoryMetric.java
+++ b/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/utils/JVMMemoryMetric.java
@@ -1,3 +1,36 @@
+/**
+ * NoiseMap is a scientific computation plugin for OrbisGIS developed in order to
+ * evaluate the noise impact on urban mobility plans. This model is
+ * based on the French standard method NMPB2008. It includes traffic-to-noise
+ * sources evaluation and sound propagation processing.
+ * <p>
+ * This version is developed at French IRSTV Institute and at IFSTTAR
+ * (http://www.ifsttar.fr/) as part of the Eval-PDU project, funded by the
+ * French Agence Nationale de la Recherche (ANR) under contract ANR-08-VILL-0005-01.
+ * <p>
+ * Noisemap is distributed under GPL 3 license. Its reference contact is Judicaël
+ * Picaut <judicael.picaut@ifsttar.fr>. It is maintained by Nicolas Fortin
+ * as part of the "Atelier SIG" team of the IRSTV Institute <http://www.irstv.fr/>.
+ * <p>
+ * Copyright (C) 2011 IFSTTAR
+ * Copyright (C) 2011-2012 IRSTV (FR CNRS 2488)
+ * <p>
+ * Noisemap is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ * <p>
+ * Noisemap is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License along with
+ * Noisemap. If not, see <http://www.gnu.org/licenses/>.
+ * <p>
+ * For more information, please consult: <http://www.orbisgis.org/>
+ * or contact directly:
+ * info_at_ orbisgis.org
+ */
 package org.noise_planet.noisemodelling.pathfinder.utils;
 
 public class JVMMemoryMetric implements ProfilerThread.Metric {

--- a/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/utils/JVMMemoryMetric.java
+++ b/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/utils/JVMMemoryMetric.java
@@ -1,0 +1,20 @@
+package org.noise_planet.noisemodelling.pathfinder.utils;
+
+public class JVMMemoryMetric implements ProfilerThread.Metric {
+    @Override
+    public String[] getColumnNames() {
+        return new String[] {"jvm_used_heap_mb", "jvm_max_heap_mb"};
+    }
+
+    @Override
+    public String[] getCurrentValues() {
+        Runtime r = Runtime.getRuntime();
+        return new String[] {Long.toString((r.totalMemory() - r.freeMemory()) / 1048576L),
+                Long.toString(r.totalMemory() / 1048576L)};
+    }
+
+    @Override
+    public void tick(long currentMillis) {
+
+    }
+}

--- a/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/utils/ProfilerThread.java
+++ b/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/utils/ProfilerThread.java
@@ -1,0 +1,81 @@
+package org.noise_planet.noisemodelling.pathfinder.utils;
+
+import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Locale;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class ProfilerThread  implements Runnable {
+    public Logger log = LoggerFactory.getLogger(ProfilerThread.class);
+    public AtomicLong timeTracker = new AtomicLong(System.currentTimeMillis());
+    public AtomicBoolean doRun = new AtomicBoolean(true);
+    private ConcurrentLinkedDeque<ReceiverProfile> receiverProfiles = new ConcurrentLinkedDeque<>();
+    private DescriptiveStatistics stats = new DescriptiveStatistics();
+    private static final int PROCESSING_TIMEOUT = 5000;
+
+    @Override
+    public void run() {
+        while (doRun.get() || !receiverProfiles.isEmpty()) {
+            timeTracker.set(System.currentTimeMillis());
+            try {
+                if(!receiverProfiles.isEmpty()) {
+                    while (!receiverProfiles.isEmpty()) {
+                        ReceiverProfile receiverProfile = receiverProfiles.pop();
+                        stats.addValue(receiverProfile.computationTime);
+                    }
+                } else {
+                    Thread.sleep(2);
+                }
+            } catch (InterruptedException ex) {
+                break;
+            }
+        }
+    }
+
+    public void printStats() {
+        if (doRun.get()) {
+            return;
+        }
+        long start = System.currentTimeMillis();
+        while (!receiverProfiles.isEmpty()) {
+            try {
+                if( System.currentTimeMillis() - start > PROCESSING_TIMEOUT) {
+                    return;
+                }
+                Thread.sleep(50);
+            } catch (InterruptedException ex) {
+                return;
+            }
+        }
+        double mean = stats.getMean();
+        double max = stats.getMax();
+        double min = stats.getMin();
+        double median = stats.getPercentile(50);
+        log.info(String.format(Locale.ROOT, "Receiver computation statistics: " +
+                "mean: %d ms  min: %d ms max: %d ms  median: %d ms",
+                (int) mean, (int) min, (int) max, (int) median));
+    }
+
+    public void clearStats() {
+        stats.clear();
+        receiverProfiles.clear();
+    }
+
+    public void onEndComputation(int receiverId, int computationTime) {
+        receiverProfiles.add(new ReceiverProfile(receiverId, computationTime));
+    }
+
+    public static class ReceiverProfile {
+        public int receiverId;
+        public int computationTime;
+
+        public ReceiverProfile(int receiverId, int computationTime) {
+            this.receiverId = receiverId;
+            this.computationTime = computationTime;
+        }
+    }
+}

--- a/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/utils/ProfilerThread.java
+++ b/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/utils/ProfilerThread.java
@@ -1,3 +1,36 @@
+/**
+ * NoiseMap is a scientific computation plugin for OrbisGIS developed in order to
+ * evaluate the noise impact on urban mobility plans. This model is
+ * based on the French standard method NMPB2008. It includes traffic-to-noise
+ * sources evaluation and sound propagation processing.
+ * <p>
+ * This version is developed at French IRSTV Institute and at IFSTTAR
+ * (http://www.ifsttar.fr/) as part of the Eval-PDU project, funded by the
+ * French Agence Nationale de la Recherche (ANR) under contract ANR-08-VILL-0005-01.
+ * <p>
+ * Noisemap is distributed under GPL 3 license. Its reference contact is Judicaël
+ * Picaut <judicael.picaut@ifsttar.fr>. It is maintained by Nicolas Fortin
+ * as part of the "Atelier SIG" team of the IRSTV Institute <http://www.irstv.fr/>.
+ * <p>
+ * Copyright (C) 2011 IFSTTAR
+ * Copyright (C) 2011-2012 IRSTV (FR CNRS 2488)
+ * <p>
+ * Noisemap is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ * <p>
+ * Noisemap is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License along with
+ * Noisemap. If not, see <http://www.gnu.org/licenses/>.
+ * <p>
+ * For more information, please consult: <http://www.orbisgis.org/>
+ * or contact directly:
+ * info_at_ orbisgis.org
+ */
 package org.noise_planet.noisemodelling.pathfinder.utils;
 
 import org.slf4j.Logger;

--- a/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/utils/ProgressMetric.java
+++ b/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/utils/ProgressMetric.java
@@ -1,3 +1,36 @@
+/**
+ * NoiseMap is a scientific computation plugin for OrbisGIS developed in order to
+ * evaluate the noise impact on urban mobility plans. This model is
+ * based on the French standard method NMPB2008. It includes traffic-to-noise
+ * sources evaluation and sound propagation processing.
+ * <p>
+ * This version is developed at French IRSTV Institute and at IFSTTAR
+ * (http://www.ifsttar.fr/) as part of the Eval-PDU project, funded by the
+ * French Agence Nationale de la Recherche (ANR) under contract ANR-08-VILL-0005-01.
+ * <p>
+ * Noisemap is distributed under GPL 3 license. Its reference contact is Judicaël
+ * Picaut <judicael.picaut@ifsttar.fr>. It is maintained by Nicolas Fortin
+ * as part of the "Atelier SIG" team of the IRSTV Institute <http://www.irstv.fr/>.
+ * <p>
+ * Copyright (C) 2011 IFSTTAR
+ * Copyright (C) 2011-2012 IRSTV (FR CNRS 2488)
+ * <p>
+ * Noisemap is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ * <p>
+ * Noisemap is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License along with
+ * Noisemap. If not, see <http://www.gnu.org/licenses/>.
+ * <p>
+ * For more information, please consult: <http://www.orbisgis.org/>
+ * or contact directly:
+ * info_at_ orbisgis.org
+ */
 package org.noise_planet.noisemodelling.pathfinder.utils;
 
 import org.h2gis.api.ProgressVisitor;

--- a/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/utils/ProgressMetric.java
+++ b/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/utils/ProgressMetric.java
@@ -1,0 +1,31 @@
+package org.noise_planet.noisemodelling.pathfinder.utils;
+
+import org.h2gis.api.ProgressVisitor;
+
+import java.util.Locale;
+
+/**
+ * Metric that write progression value in percentage
+ */
+public class ProgressMetric implements ProfilerThread.Metric {
+    private ProgressVisitor progressVisitor;
+
+    public ProgressMetric(ProgressVisitor progressVisitor) {
+        this.progressVisitor = progressVisitor;
+    }
+
+    @Override
+    public String[] getColumnNames() {
+        return new String[] {"progression"};
+    }
+
+    @Override
+    public String[] getCurrentValues() {
+        return new String[] {String.format(Locale.ROOT, "%.2f", progressVisitor.getProgression() *  100.0)};
+    }
+
+    @Override
+    public void tick(long currentMillis) {
+
+    }
+}

--- a/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/utils/ReceiverStatsMetric.java
+++ b/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/utils/ReceiverStatsMetric.java
@@ -1,3 +1,36 @@
+/**
+ * NoiseMap is a scientific computation plugin for OrbisGIS developed in order to
+ * evaluate the noise impact on urban mobility plans. This model is
+ * based on the French standard method NMPB2008. It includes traffic-to-noise
+ * sources evaluation and sound propagation processing.
+ * <p>
+ * This version is developed at French IRSTV Institute and at IFSTTAR
+ * (http://www.ifsttar.fr/) as part of the Eval-PDU project, funded by the
+ * French Agence Nationale de la Recherche (ANR) under contract ANR-08-VILL-0005-01.
+ * <p>
+ * Noisemap is distributed under GPL 3 license. Its reference contact is Judicaël
+ * Picaut <judicael.picaut@ifsttar.fr>. It is maintained by Nicolas Fortin
+ * as part of the "Atelier SIG" team of the IRSTV Institute <http://www.irstv.fr/>.
+ * <p>
+ * Copyright (C) 2011 IFSTTAR
+ * Copyright (C) 2011-2012 IRSTV (FR CNRS 2488)
+ * <p>
+ * Noisemap is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ * <p>
+ * Noisemap is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License along with
+ * Noisemap. If not, see <http://www.gnu.org/licenses/>.
+ * <p>
+ * For more information, please consult: <http://www.orbisgis.org/>
+ * or contact directly:
+ * info_at_ orbisgis.org
+ */
 package org.noise_planet.noisemodelling.pathfinder.utils;
 
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;

--- a/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/utils/ReceiverStatsMetric.java
+++ b/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/utils/ReceiverStatsMetric.java
@@ -34,12 +34,14 @@ public class ReceiverStatsMetric implements ProfilerThread.Metric {
 
     @Override
     public String[] getCurrentValues() {
-        return new String[] {
+        String[] res = new String[] {
                 Integer.toString((int)stats.getMin()),
                 Integer.toString((int)stats.getPercentile(50)),
                 Integer.toString((int)stats.getMean()),
                 Integer.toString((int)stats.getMax())
         };
+        stats.clear();
+        return res;
     }
 
     public static class ReceiverProfile {

--- a/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/utils/ReceiverStatsMetric.java
+++ b/noisemodelling-pathfinder/src/main/java/org/noise_planet/noisemodelling/pathfinder/utils/ReceiverStatsMetric.java
@@ -1,0 +1,54 @@
+package org.noise_planet.noisemodelling.pathfinder.utils;
+
+import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
+
+import java.util.concurrent.ConcurrentLinkedDeque;
+
+/**
+ * Generate stats about receiver computation time
+ */
+public class ReceiverStatsMetric implements ProfilerThread.Metric {
+    public static final String RECEIVER_COMPUTATION_TIME = "RECEIVER_COMPUTATION_TIME";
+    private ConcurrentLinkedDeque<ReceiverProfile> receiverProfiles = new ConcurrentLinkedDeque<>();
+    private DescriptiveStatistics stats = new DescriptiveStatistics();
+
+    public ReceiverStatsMetric() {
+    }
+
+    @Override
+    public void tick(long currentMillis) {
+        while (!receiverProfiles.isEmpty()) {
+            ReceiverProfile receiverProfile = receiverProfiles.pop();
+            stats.addValue(receiverProfile.computationTime);
+        }
+    }
+
+    @Override
+    public String[] getColumnNames() {
+        return new String[] {"receiver_min","receiver_median","receiver_mean","receiver_max"};
+    }
+
+    public void onEndComputation(int receiverId, int computationTime) {
+        receiverProfiles.add(new ReceiverProfile(receiverId, computationTime));
+    }
+
+    @Override
+    public String[] getCurrentValues() {
+        return new String[] {
+                Integer.toString((int)stats.getMin()),
+                Integer.toString((int)stats.getPercentile(50)),
+                Integer.toString((int)stats.getMean()),
+                Integer.toString((int)stats.getMax())
+        };
+    }
+
+    public static class ReceiverProfile {
+        public int receiverId;
+        public int computationTime;
+
+        public ReceiverProfile(int receiverId, int computationTime) {
+            this.receiverId = receiverId;
+            this.computationTime = computationTime;
+        }
+    }
+}

--- a/noisemodelling-pathfinder/src/test/java/org/noise_planet/noisemodelling/pathfinder/TestWallReflection.java
+++ b/noisemodelling-pathfinder/src/test/java/org/noise_planet/noisemodelling/pathfinder/TestWallReflection.java
@@ -108,7 +108,7 @@ public class TestWallReflection extends TestCase {
 
 	public static List<MirrorReceiverResult> getReceiverImages(Coordinate receiver, Coordinate source, List<FastObstructionTest.Wall> walls, int order) {
         MirrorReceiverIterator.It mirrorReceiverResults =
-                new MirrorReceiverIterator.It(receiver, walls, new LineSegment(source, receiver), 9999, order, 9999);
+                new MirrorReceiverIterator.It(receiver, walls, 9999, order, 9999);
 
         List<MirrorReceiverResult> res = new ArrayList<>();
         for(MirrorReceiverResult r : mirrorReceiverResults) {
@@ -240,7 +240,7 @@ public class TestWallReflection extends TestCase {
         Coordinate source = new Coordinate(9, 4);
 
         MirrorReceiverIterator.It mirrorReceiverResults =
-                new MirrorReceiverIterator.It(receiver, walls, new LineSegment(source, receiver), 20, 2, 40);
+                new MirrorReceiverIterator.It(receiver, walls, 20, 2, 40);
         Iterator<MirrorReceiverResult> it = mirrorReceiverResults.iterator();
         wallTest(new Coordinate(0, 2), new int[]{0}, it.next());
         wallTest(new Coordinate(6, 2), new int[]{0, 4}, it.next());
@@ -340,7 +340,10 @@ public class TestWallReflection extends TestCase {
                 data.maxRefDist, source, false);
         assertEquals(13, walls.size());
         List<PropagationPath> paths;
-        paths = computeRays.computeReflexion(receiver, source, false, walls);
+        List<MirrorReceiverResult> mirrorReceiverResults = new ArrayList<>();
+        new MirrorReceiverIterator.It(receiver, walls,
+                Integer.MAX_VALUE, data.reflexionOrder, data.maxSrcDist).forEach(mirrorReceiverResults::add);
+        paths = computeRays.computeReflexion(receiver, source, false, walls, mirrorReceiverResults);
         assertEquals(1, paths.size());
         List<PointPath> pts = paths.get(0).getPointList();
         assertEquals(3, pts.size());
@@ -352,7 +355,10 @@ public class TestWallReflection extends TestCase {
         assertEquals(0, receiver.distance(pts.get(2).coordinate), 1e-6);
 
         data.reflexionOrder = 2;
-        paths = computeRays.computeReflexion(receiver, source, false, walls);
+        mirrorReceiverResults = new ArrayList<>();
+        new MirrorReceiverIterator.It(receiver, walls,
+                Integer.MAX_VALUE, data.reflexionOrder, data.maxSrcDist).forEach(mirrorReceiverResults::add);
+        paths = computeRays.computeReflexion(receiver, source, false, walls, mirrorReceiverResults);
         assertEquals(2, paths.size());
         pts = paths.get(1).getPointList();
         // 2 ref points

--- a/noisemodelling-propagation/src/main/java/org/noise_planet/noisemodelling/propagation/ComputeRaysOutAttenuation.java
+++ b/noisemodelling-propagation/src/main/java/org/noise_planet/noisemodelling/propagation/ComputeRaysOutAttenuation.java
@@ -240,7 +240,7 @@ public class ComputeRaysOutAttenuation implements IComputeRaysOut {
     }
 
     @Override
-    public IComputeRaysOut subProcess(int receiverStart, int receiverEnd) {
+    public IComputeRaysOut subProcess() {
         return new ThreadRaysOut(this);
     }
 
@@ -394,8 +394,8 @@ public class ComputeRaysOutAttenuation implements IComputeRaysOut {
         }
 
         @Override
-        public IComputeRaysOut subProcess(int receiverStart, int receiverEnd) {
-            return multiThreadParent.subProcess(receiverStart, receiverEnd);
+        public IComputeRaysOut subProcess() {
+            return multiThreadParent.subProcess();
         }
     }
 }

--- a/noisemodelling-tutorial-01/src/main/java/org/noise_planet/nmtutorial01/main.java
+++ b/noisemodelling-tutorial-01/src/main/java/org/noise_planet/nmtutorial01/main.java
@@ -7,6 +7,7 @@ import org.h2gis.api.ProgressVisitor;
 import org.h2gis.functions.io.csv.CSVDriverFunction;
 import org.h2gis.functions.io.geojson.GeoJsonRead;
 import org.h2gis.utilities.SFSUtilities;
+import org.noise_planet.noisemodelling.pathfinder.utils.JVMMemoryMetric;
 import org.noise_planet.noisemodelling.pathfinder.utils.KMLDocument;
 import org.noise_planet.noisemodelling.jdbc.LDENConfig;
 import org.noise_planet.noisemodelling.jdbc.LDENPointNoiseMapFactory;
@@ -14,6 +15,8 @@ import org.noise_planet.noisemodelling.jdbc.PointNoiseMap;
 import org.noise_planet.noisemodelling.pathfinder.FastObstructionTest;
 import org.noise_planet.noisemodelling.pathfinder.IComputeRaysOut;
 import org.noise_planet.noisemodelling.pathfinder.RootProgressVisitor;
+import org.noise_planet.noisemodelling.pathfinder.utils.ProfilerThread;
+import org.noise_planet.noisemodelling.pathfinder.utils.ProgressMetric;
 import org.noise_planet.noisemodelling.propagation.ComputeRaysOutAttenuation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -135,8 +138,15 @@ class Main {
         long start = System.currentTimeMillis();
 
         // Iterate over computation areas
+        ProfilerThread profilerThread = new ProfilerThread(new File("target/profile.csv"));
+        profilerThread.addMetric(tableWriter);
+        profilerThread.addMetric(new ProgressMetric(progressLogger));
+        profilerThread.addMetric(new JVMMemoryMetric());
+        profilerThread.setWriteInterval(2);
+        pointNoiseMap.setProfilerThread(profilerThread);
         try {
             tableWriter.start();
+            new Thread(profilerThread).start();
             // Fetch cell identifiers with receivers
             Map<PointNoiseMap.CellIndex, Integer> cells = pointNoiseMap.searchPopulatedCells(connection);
             ProgressVisitor progressVisitor = progressLogger.subProcess(cells.size());
@@ -150,8 +160,10 @@ class Main {
                 }
             }
         } finally {
+            profilerThread.stop();
             tableWriter.stop();
         }
+
         long computationTime = System.currentTimeMillis() - start;
         logger.info(String.format(Locale.ROOT, "Computed in %d ms, %.2f ms per receiver", computationTime,computationTime / (double)receivers.size()));
         // Export result tables as csv files

--- a/noisemodelling-tutorial-01/src/main/java/org/noise_planet/nmtutorial01/main.java
+++ b/noisemodelling-tutorial-01/src/main/java/org/noise_planet/nmtutorial01/main.java
@@ -95,7 +95,7 @@ class Main {
         PointNoiseMap pointNoiseMap = new PointNoiseMap("BUILDINGS", "LW_ROADS", "RECEIVERS");
 
         pointNoiseMap.setMaximumPropagationDistance(160.0d);
-        pointNoiseMap.setSoundReflectionOrder(0);
+        pointNoiseMap.setSoundReflectionOrder(2);
         pointNoiseMap.setComputeHorizontalDiffraction(true);
         pointNoiseMap.setComputeVerticalDiffraction(true);
         // Building height field name
@@ -128,7 +128,7 @@ class Main {
         pointNoiseMap.initialize(connection, new EmptyProgressVisitor());
 
         // force the creation of a 2x2 cells
-        pointNoiseMap.setGridDim(2);
+        pointNoiseMap.setGridDim(1);
 
 
         // Set of already processed receivers
@@ -143,6 +143,7 @@ class Main {
         profilerThread.addMetric(new ProgressMetric(progressLogger));
         profilerThread.addMetric(new JVMMemoryMetric());
         profilerThread.setWriteInterval(2);
+        profilerThread.setFlushInterval(15);
         pointNoiseMap.setProfilerThread(profilerThread);
         try {
             tableWriter.start();

--- a/noisemodelling-tutorial-01/src/main/java/org/noise_planet/nmtutorial01/main.java
+++ b/noisemodelling-tutorial-01/src/main/java/org/noise_planet/nmtutorial01/main.java
@@ -95,7 +95,7 @@ class Main {
         PointNoiseMap pointNoiseMap = new PointNoiseMap("BUILDINGS", "LW_ROADS", "RECEIVERS");
 
         pointNoiseMap.setMaximumPropagationDistance(160.0d);
-        pointNoiseMap.setSoundReflectionOrder(2);
+        pointNoiseMap.setSoundReflectionOrder(0);
         pointNoiseMap.setComputeHorizontalDiffraction(true);
         pointNoiseMap.setComputeVerticalDiffraction(true);
         // Building height field name
@@ -118,7 +118,7 @@ class Main {
 
         LDENPointNoiseMapFactory tableWriter = new LDENPointNoiseMapFactory(connection, ldenConfig);
 
-        tableWriter.setKeepRays(true);
+        tableWriter.setKeepRays(false);
 
         pointNoiseMap.setPropagationProcessDataFactory(tableWriter);
         pointNoiseMap.setComputeRaysOutFactory(tableWriter);
@@ -128,7 +128,7 @@ class Main {
         pointNoiseMap.initialize(connection, new EmptyProgressVisitor());
 
         // force the creation of a 2x2 cells
-        pointNoiseMap.setGridDim(1);
+        pointNoiseMap.setGridDim(2);
 
 
         // Set of already processed receivers

--- a/wps_scripts/src/main/groovy/org/noise_planet/noisemodelling/wps/Experimental/Get_Rayz.groovy
+++ b/wps_scripts/src/main/groovy/org/noise_planet/noisemodelling/wps/Experimental/Get_Rayz.groovy
@@ -468,7 +468,7 @@ class PropagationPathStorage extends ComputeRaysOutAttenuation {
     }
 
     @Override
-    IComputeRaysOut subProcess(int i, int i1) {
+    IComputeRaysOut subProcess() {
         return new PropagationPathStorageThread(this)
     }
 
@@ -518,7 +518,7 @@ class PropagationPathStorage extends ComputeRaysOutAttenuation {
         }
 
         @Override
-        IComputeRaysOut subProcess(int receiverStart, int receiverEnd) {
+        IComputeRaysOut subProcess() {
             return null
         }
 

--- a/wps_scripts/src/main/groovy/org/noise_planet/noisemodelling/wps/NoiseModelling/Noise_level_from_source.groovy
+++ b/wps_scripts/src/main/groovy/org/noise_planet/noisemodelling/wps/NoiseModelling/Noise_level_from_source.groovy
@@ -32,6 +32,9 @@ import org.locationtech.jts.geom.GeometryFactory
 
 import org.noise_planet.noisemodelling.emission.*
 import org.noise_planet.noisemodelling.pathfinder.*
+import org.noise_planet.noisemodelling.pathfinder.utils.JVMMemoryMetric
+import org.noise_planet.noisemodelling.pathfinder.utils.ProfilerThread
+import org.noise_planet.noisemodelling.pathfinder.utils.ProgressMetric
 import org.noise_planet.noisemodelling.propagation.*
 import org.noise_planet.noisemodelling.jdbc.*
 
@@ -549,8 +552,16 @@ def exec(Connection connection, input) {
     RootProgressVisitor progressLogger = new RootProgressVisitor(1, true, 1)
 
     logger.info("Start calculation... ")
+    ProfilerThread profilerThread = new ProfilerThread(new File("webapps/root/profile.csv"));
+    profilerThread.addMetric(ldenProcessing);
+    profilerThread.addMetric(new ProgressMetric(progressLogger));
+    profilerThread.addMetric(new JVMMemoryMetric());
+    profilerThread.setWriteInterval(300);
+    profilerThread.setFlushInterval(300);
+    pointNoiseMap.setProfilerThread(profilerThread);
     try {
         ldenProcessing.start()
+        new Thread(profilerThread).start();
         // Iterate over computation areas
         int k = 0
         Map cells = pointNoiseMap.searchPopulatedCells(connection);
@@ -565,6 +576,7 @@ def exec(Connection connection, input) {
             pointNoiseMap.evaluateCell(connection, cellIndex.getLatitudeIndex(), cellIndex.getLongitudeIndex(), progressVisitor, receivers)
         }
     } finally {
+        profilerThread.stop();
         ldenProcessing.stop()
     }
 


### PR DESCRIPTION
- Propagation code now output a profiler csv file that helps to find bottleneck in the simulation (memory or writing speed on hdd)
- Now NoiseModelling is better able to maintain a constant number of active concurrent processes until the end of the simulation.
- Primary keys on lday, levening, lnight and lden are now applied only after all the insertion of rows (should be noticeable for large results)
- Precompute the position of image receivers before fetching the source. Instead of fetching the receiver image at each point source

The same simulation (2 order of reflection) Before and after the optimization on pre-computation of the position of image receivers

![tempscalcul](https://user-images.githubusercontent.com/1382241/127287380-2c26202f-bf43-4ae1-99dd-24dc615b5022.png)

![mémoire](https://user-images.githubusercontent.com/1382241/127287457-afbd8233-44b9-4dcd-8e1c-9850fdddbe0c.png)

