### PR TITLE
do not add constraint for cell exterior envelope, use vertices instead

### DIFF
--- a/noisemodelling-jdbc/src/main/java/org/noise_planet/noisemodelling/jdbc/TriangleNoiseMap.java
+++ b/noisemodelling-jdbc/src/main/java/org/noise_planet/noisemodelling/jdbc/TriangleNoiseMap.java
@@ -252,10 +252,16 @@ public class TriangleNoiseMap extends JdbcNoiseMap {
         if (maximumArea > 1) {
             double triangleSide = (2*Math.pow(maximumArea, 0.5)) / Math.pow(3, 0.25);
             Polygon polygon = (Polygon)Densifier.densify(new GeometryFactory().toGeometry(cellEnvelope), triangleSide);
-            cellMesh.addLineString(polygon.getExteriorRing(), 0);
+            Coordinate[] points = polygon.getExteriorRing().getCoordinates();
+            for(Coordinate point : points) {
+                cellMesh.addVertex(point);
+            }
         } else {
             Polygon polygon = (Polygon) new GeometryFactory().toGeometry(cellEnvelope);
-            cellMesh.addLineString(polygon.getExteriorRing(), 0);
+            Coordinate[] points = polygon.getExteriorRing().getCoordinates();
+            for(Coordinate point : points) {
+                cellMesh.addVertex(point);
+            }
         }
         cellMesh.processDelaunay();
         logger.info("End delaunay");


### PR DESCRIPTION
Collinear constraints provided by envelope bound box over roads and/or buildings may trigger infinite loop into tinfour. So use points from envelope instead of constraint lines. 

@gwlucastrig
here t = infinite
https://github.com/gwlucastrig/Tinfour/blob/2.1.7/core/src/main/java/org/tinfour/standard/IncrementalTin.java#L2122

